### PR TITLE
HDOS-401 frontend error on released workflow

### DIFF
--- a/frontend/src/app/components/workflow-editor/workflow-editor.component.ts
+++ b/frontend/src/app/components/workflow-editor/workflow-editor.component.ts
@@ -500,7 +500,7 @@ export class WorkflowEditorComponent {
   }
 
   private _updateWorkflowIfNecessary(): void {
-    if (!this.hasChanges) {
+    if (!this.hasChanges || this.currentWorkflow.state === 'RELEASED') {
       return;
     }
     this.workflowService.updateWorkflow(this.currentWorkflow);


### PR DESCRIPTION
fix(workflow-editor):
Added a second condition that triggers, if the workflow is already released and returns back.
This will intercept updating the workflow in a released state.