### PR TITLE
HDOS-283 Frozen Progress bar

### DIFF
--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -9,7 +9,10 @@ import {
 } from '@angular/material/dialog';
 import { MAT_FORM_FIELD_DEFAULT_OPTIONS } from '@angular/material/form-field';
 import { BrowserModule } from '@angular/platform-browser';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import {
+  ANIMATION_MODULE_TYPE,
+  BrowserAnimationsModule
+} from '@angular/platform-browser/animations';
 import {
   OwlDateTimeModule,
   OwlNativeDateTimeModule
@@ -164,7 +167,8 @@ import { appReducers } from './store/app.reducers';
         };
       },
       deps: [ConfigService, ThemeService]
-    }
+    },
+    { provide: ANIMATION_MODULE_TYPE, useValue: 'BrowserAnimations' }
   ],
   bootstrap: [AppComponent]
 })

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -168,6 +168,8 @@ import { appReducers } from './store/app.reducers';
       },
       deps: [ConfigService, ThemeService]
     },
+    // Fix for Frozen Progress bar animation, in an *ngIf condition.
+    // https://github.com/angular/components/issues/11453#issuecomment-466038415
     { provide: ANIMATION_MODULE_TYPE, useValue: 'BrowserAnimations' }
   ],
   bootstrap: [AppComponent]


### PR DESCRIPTION
fix:
Frozen Progress bar animation, is a known bug when used
in an *ngIf condition.
Solution  provide: ANIMATION_MODULE_TYPE, useValue: 'BrowserAnimations'.
For more infos see: https://github.com/angular/components/issues/11453#issuecomment-466038415