### PR TITLE
HDOS-311 Editor set readOnly

### DIFF
--- a/frontend/src/app/components/component-editor/component-editor.component.html
+++ b/frontend/src/app/components/component-editor/component-editor.component.html
@@ -1,4 +1,9 @@
 <div class="h-100 overflow-hidden">
-  <ngx-monaco-editor [options]="editorOptions" [(ngModel)]="code" class="h-100">
+  <ngx-monaco-editor
+    #monacoEditor
+    [options]="editorOptions"
+    [(ngModel)]="code"
+    class="h-100"
+  >
   </ngx-monaco-editor>
 </div>

--- a/frontend/src/app/components/component-editor/component-editor.component.html
+++ b/frontend/src/app/components/component-editor/component-editor.component.html
@@ -1,9 +1,4 @@
 <div class="h-100 overflow-hidden">
-  <ngx-monaco-editor
-    #monacoEditor
-    [options]="editorOptions"
-    [(ngModel)]="code"
-    class="h-100"
-  >
+  <ngx-monaco-editor [options]="editorOptions" [(ngModel)]="code" class="h-100">
   </ngx-monaco-editor>
 </div>

--- a/frontend/src/app/components/component-editor/component-editor.component.ts
+++ b/frontend/src/app/components/component-editor/component-editor.component.ts
@@ -1,5 +1,4 @@
-import { Component, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
-import { EditorComponent } from 'ngx-monaco-editor';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { Subject } from 'rxjs';
 import { debounceTime, takeUntil } from 'rxjs/operators';
 import { RevisionState } from 'src/app/enums/revision-state';
@@ -42,15 +41,15 @@ export class ComponentEditorComponent implements OnInit, OnDestroy {
     this._componentBaseItem = componentBaseItem;
     this.code = this.componentBaseItem.code;
     this.lastSaved = this.componentBaseItem.code;
-    this.editorOptions.readOnly =
-      this.componentBaseItem.state !== RevisionState.DRAFT;
+    this.editorOptions = {
+      ...this.editorOptions,
+      readOnly: this.componentBaseItem.state !== RevisionState.DRAFT
+    };
   }
 
   get componentBaseItem(): ComponentBaseItem {
     return this._componentBaseItem;
   }
-
-  @ViewChild('monacoEditor') monacoEditor: EditorComponent;
 
   constructor(
     private readonly componentService: ComponentEditorService,
@@ -87,18 +86,7 @@ export class ComponentEditorComponent implements OnInit, OnDestroy {
   }
 
   public set code(code: string) {
-    if (this.componentBaseItem.state !== RevisionState.DRAFT) {
-      this.setEditorReadOnly(true);
-    }
-
     this.codeCopy = code;
     this._autoSave$.next();
-  }
-
-  private setEditorReadOnly(readOnly: boolean): void {
-    if (this.monacoEditor !== undefined) {
-      this.editorOptions.readOnly = readOnly;
-      this.monacoEditor.options = this.editorOptions;
-    }
   }
 }

--- a/frontend/src/app/components/component-editor/component-editor.component.ts
+++ b/frontend/src/app/components/component-editor/component-editor.component.ts
@@ -43,7 +43,7 @@ export class ComponentEditorComponent implements OnInit, OnDestroy {
     this.code = this.componentBaseItem.code;
     this.lastSaved = this.componentBaseItem.code;
     this.editorOptions.readOnly =
-      this.componentBaseItem.state === RevisionState.RELEASED;
+      this.componentBaseItem.state !== RevisionState.DRAFT;
   }
 
   get componentBaseItem(): ComponentBaseItem {
@@ -87,12 +87,18 @@ export class ComponentEditorComponent implements OnInit, OnDestroy {
   }
 
   public set code(code: string) {
+    if (this.componentBaseItem.state !== RevisionState.DRAFT) {
+      this.setEditorReadOnly(true);
+    }
+
     this.codeCopy = code;
     this._autoSave$.next();
   }
 
-  public setEditorReadOnly(readOnly: boolean): void {
-    const editor = this.monacoEditor;
-    editor.options.readOnly = readOnly;
+  private setEditorReadOnly(readOnly: boolean): void {
+    if (this.monacoEditor !== undefined) {
+      this.editorOptions.readOnly = readOnly;
+      this.monacoEditor.options = this.editorOptions;
+    }
   }
 }

--- a/frontend/src/app/components/component-editor/component-editor.component.ts
+++ b/frontend/src/app/components/component-editor/component-editor.component.ts
@@ -1,4 +1,5 @@
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { EditorComponent } from 'ngx-monaco-editor';
 import { Subject } from 'rxjs';
 import { debounceTime, takeUntil } from 'rxjs/operators';
 import { RevisionState } from 'src/app/enums/revision-state';
@@ -49,6 +50,8 @@ export class ComponentEditorComponent implements OnInit, OnDestroy {
     return this._componentBaseItem;
   }
 
+  @ViewChild('monacoEditor') monacoEditor: EditorComponent;
+
   constructor(
     private readonly componentService: ComponentEditorService,
     private readonly themeService: ThemeService
@@ -86,5 +89,10 @@ export class ComponentEditorComponent implements OnInit, OnDestroy {
   public set code(code: string) {
     this.codeCopy = code;
     this._autoSave$.next();
+  }
+
+  public setEditorReadOnly(readOnly: boolean): void {
+    const editor = this.monacoEditor;
+    editor.options.readOnly = readOnly;
   }
 }


### PR DESCRIPTION
fix:
Added a method to set the monaco editor to readOnly at runtime.
This fixed a bug when releasing a component,
you could still edit the source code.
Only after a new initialization readOnly would be set.