### PR TITLE
HDOS-539

### DIFF
--- a/frontend/src/app/components/copy-transformation-dialog/copy-transformation-dialog.component.ts
+++ b/frontend/src/app/components/copy-transformation-dialog/copy-transformation-dialog.component.ts
@@ -21,7 +21,6 @@ import { UniqueVersionTagValidator } from 'src/app/validation/unique-version-tag
 export class CopyTransformationDialogComponent implements OnInit {
   constructor(
     public dialogRef: MatDialogRef<CopyTransformationDialogComponent>,
-    // TODO fix by reference value changes?
     @Inject(MAT_DIALOG_DATA)
     public data: Omit<TransformationDialogData, 'content'>,
     private readonly transformationStore: Store<TransformationState>

--- a/frontend/src/app/service/transformation/transformation-action.service.ts
+++ b/frontend/src/app/service/transformation/transformation-action.service.ts
@@ -158,7 +158,7 @@ export class TransformationActionService {
         actionCancel: 'Cancel',
         deleteButtonText: 'Delete Draft',
         showDeleteButton: transformation.state === RevisionState.DRAFT,
-        transformation,
+        transformation: Utils.deepCopy(transformation),
         disabledState: {
           name: isReleased,
           category: isReleased,


### PR DESCRIPTION
fix:
- Transformation is now passed by value via deepCopy and not by reference, this fixes not intended changes on the original.