### PR TITLE
Integrate pytorch into blob storage adapter

### DIFF
--- a/Dockerfile-runtime
+++ b/Dockerfile-runtime
@@ -1,7 +1,7 @@
 ##### Build stage
 FROM --platform=linux/amd64 python:3.10.8-slim-bullseye as base
 
-ENV TIMEOUT=900
+ENV TIMEOUT=4500
 
 # Copy relevant files
 COPY ./runtime/pipt_locks.env /app/pipt_locks.env

--- a/runtime/hetdesrun/adapters/blob_storage/load_blob.py
+++ b/runtime/hetdesrun/adapters/blob_storage/load_blob.py
@@ -129,18 +129,7 @@ async def load_blob_from_storage(thing_node_id: str, metadata_key: str) -> Any:
         else:
             logger.info("Successfully imported torch")
             file_object = BytesIO(response["Body"].read())
-            custom_objects: dict[str, Any] | None = None
-            custom_objects_object_key = object_key.to_custom_objects_object_key()
-            try:
-                custom_objects_response = get_object(
-                    s3_client=s3_client,
-                    bucket_name=bucket.name,
-                    object_key_string=custom_objects_object_key.string,
-                )
-            except s3_client.exceptions.NoSuchKey:
-                pass
-            else:
-                data = tjit.load(file_object)  # TODO wrap in try block?
+            data = tjit.load(file_object, map_location="cpu")
     else:
         data = pickle.load(response["Body"])
 

--- a/runtime/hetdesrun/adapters/blob_storage/load_blob.py
+++ b/runtime/hetdesrun/adapters/blob_storage/load_blob.py
@@ -116,6 +116,31 @@ async def load_blob_from_storage(thing_node_id: str, metadata_key: str) -> Any:
                 custom_objects = pickle.load(custom_objects_response["Body"])
             with h5py.File(file_object, "r") as f:
                 data = tf.keras.saving.load_model(f, custom_objects=custom_objects)
+    elif object_key.file_extension == FileExtension.PT:
+        try:
+            import torch.jit as tjit
+        except ModuleNotFoundError as error:
+            msg = (
+                "To load a model from a BLOB in the pt format, "
+                f"add torch to the runtime dependencies:\n{error}"
+            )
+            logger.error(msg)
+            raise AdapterHandlingException(msg) from error
+        else:
+            logger.info("Successfully imported torch")
+            file_object = BytesIO(response["Body"].read())
+            custom_objects: dict[str, Any] | None = None
+            custom_objects_object_key = object_key.to_custom_objects_object_key()
+            try:
+                custom_objects_response = get_object(
+                    s3_client=s3_client,
+                    bucket_name=bucket.name,
+                    object_key_string=custom_objects_object_key.string,
+                )
+            except s3_client.exceptions.NoSuchKey:
+                pass
+            else:
+                data = tjit.load(file_object)  # TODO wrap in try block?
     else:
         data = pickle.load(response["Body"])
 

--- a/runtime/hetdesrun/adapters/blob_storage/models.py
+++ b/runtime/hetdesrun/adapters/blob_storage/models.py
@@ -40,6 +40,7 @@ class FileExtension(str, Enum):
 
     H5 = "h5"
     Pickle = "pkl"
+    PT = "pt"
     CustomObjectsPkl = "custom_objects_pkl"
 
 


### PR DESCRIPTION
Enables the blob storage adapter to load Pytorch models in TorchScript-format, stored .pt-files, for CPU-inference.