### PR TITLE
enable additional column names in multitsframes in generic rest adapter

### DIFF
--- a/docs/datatypes/multitsframes.md
+++ b/docs/datatypes/multitsframes.md
@@ -3,24 +3,48 @@
 
 MultiTSFrames represents multiple timeseries (of same dimension) data with non-necessarily common timestamps.
 
-Data is stored in records, one per metric per timestamp where this metric has value(s), i.e. in "long format", e.g.
+Data is stored in records, one per metric per timestamp where this metric has value(s), i.e. in "long format".
+This is in contrast to "wide format" where each metric is its own column. A main advantage of the long-format is
+that it is more storage-efficient in case that multiple timeseries do not have the same timestamps.
 
-timestamp, metric, value
-2024-12-01T01:00:00+00:00
-....
+<table>
+<tr><th>long format </th><th> wide format</th></tr>
+<tr><td>
 
+| timestamp                 |  metric  | value |
+| :-----------------------: | :------: | :---: |
+| 2024-12-01T01:00:00+00:00 |     A    | 23.99 |
+| 2024-12-01T01:00:00+00:00 |     B    | 23.99 |
+| 2024-12-01T01:00:00+00:00 |     C    | 19.99 |
+| 2024-12-01T01:00:00+00:00 |     D    | 42.99 |
+| 2024-12-01T02:00:00+00:00 |     A    | 24.99 |
+| 2024-12-01T02:00:00+00:00 |     B    | 22.99 |
+| 2024-12-01T02:00:00+00:00 |     C    | 18.99 |
+| 2024-12-01T03:00:00+00:00 |     D    | 45.99 |
 
-This is in contrast to "wide format" where each metric is its own column.
+</td><td>
 
-A main advantage of the long-format is that it is more storage-efficient in case that multiple timeseries do not have the same timestamps.
+| timestamp                 |  A    |   B   |   C   |   D   |
+| :-----------------------: | :---: | :---: | :---: | :---: |
+| 2024-12-01T01:00:00+00:00 | 23.99 | 23.99 | 19.99 | 42.99 |
+| 2024-12-01T02:00:00+00:00 | 24.99 | 22.99 | 18.99 |       |
+| 2024-12-01T03:00:00+00:00 |       |       |       | 45.99 |
 
-A MultiTSFrame must have at least three columns: 
+</td></tr> </table>
+
+A MultiTSFrame must have at least three columns:
 * a "timestamp" column (datetime, no missing entries allowed)
 * a "metric" column (string, no missing entries allowed)
 * at least one value column: Per convention the third column is often named "value". Many base components assume only the three columns "timestamp", "metric" and "value".
 
-TODO: reformulate "multi-dimensional"
-In case the MultiTSFrame contains timeseries where the timestamps are always the same, e.g., when a series is aggregated for a certain frequency using different functions, it might be useful to return a MultiTSFrame with additional columns. This is a special case and should only be applied, when it is clear that the stored timeseries will never have different timestamps.
+A special case of a MultiTSFrame are multi-dimensional timeseries . For example, such a multi-dimensional timeseries
+is a climate station that measures temperature, precipitation and air pressure at the same time. In this case, the MultiTSFrame contains mutiple timeseries where the timestamps are always the same. Hereby it is useful to return a MultiTSFrame with additional columns. An example for multi-dimensional timeseries of two climate stations using a multiTSFrame with additonal columns is shown below.
+
+| timestamp                 |  metric     |temp |prec |  pres |
+| :-----------------------: | :---------: | :-: | :-: | :---: |
+| 2024-12-01T01:00:00+00:00 |  station A  | 0.2 | 0.0 | 1014. |
+| 2024-12-01T02:00:00+00:00 |  station A  | 0.3 | 0.2 | 1015. |
+| 2024-12-01T01:01:00+00:00 |  station B  | 0.1 | 0.0 | 1013. |
 
 
 ## Internal: Workflow & Components
@@ -34,7 +58,9 @@ Note that Pandas will handle a column build from values of differing types as dt
 In contrast to pandas.Series the index of a MultiTSFrame should be considered irrelevant since timestamp information is in the "timestamp" column. When manipulating MultiTSFrame Pandas DataFrames you should ensure that the resulting index is duplicate-free. Ideally a generic integer index.
 
 In the documentation of the workflow and components the convention is to write **MultiTSFrame**, e.g.:
+```
 - mutiple_timeseries (MultiTSFrame): This is an example for the documentation of an input/output with the type MultiTSFrame
+```
 
 ## External: Adapter System
 ### [Manual Input / Direct Provisioning](../adapter_system/manual_input.md)
@@ -59,8 +85,41 @@ To define a MultiTSFrame a json of the following format can be defined:
     ]
 }
 ```
+It is also possible to define metadata for the MultiTSFrame.
+Conventions for the metadata keys can be found [here](../metadata_attrs.md).
+For such cases, we recommend using the `wrapped format`, e.g.:
+```json
+{
+    "__hd_wrapped_data_object__": "DATAFRAME",
+    "__metadata__": {
+        "ref_data_frequency": {
+            "a": 1h,
+            "b": 1h
+        }
+    },
+    "__data__": {
+        "value": {
+            "0": 1,
+            "1": 1.2,
+            "2": 0.5,
+            "3": 0.4,
+        },
+        "metric": {
+            "0": "a",
+            "1": "a",
+            "2": "b",
+            "3": "b"
+        },
+        "timestamp": {
+            "0": "2019-08-01T01:00:00.000Z",
+            "1": "2019-08-01T02:00:00.000Z",
+            "2": "2019-08-01T01:00:00.000Z",
+            "2": "2019-08-01T02:00:00.000Z"
+        }
+    }
+}
+```
 
-TODO: mention wrapped format!
 
 **Tip**: Having a Pandas DataFrame variable `df` (e.g. in a jupyter notebook) with these 3 columns you can obtain this format by calling the `to_json` method with `orient="columns", date_format="iso"`:
 ```python

--- a/docs/datatypes/multitsframes.md
+++ b/docs/datatypes/multitsframes.md
@@ -85,7 +85,12 @@ To define a MultiTSFrame a json of the following format can be defined:
     ]
 }
 ```
-It is also possible to define metadata for the MultiTSFrame.
+**Tip**: Having a Pandas DataFrame variable `df` (e.g. in a jupyter notebook) with these 3 columns you can obtain this format by calling the `to_json` method with `orient="columns", date_format="iso"`:
+```python
+print(df.to_json(orient="columns", date_format="iso", indent=2))
+```
+
+It is possible to define metadata for the MultiTSFrame.
 Conventions for the metadata keys can be found [here](../metadata_attrs.md).
 For such cases, we recommend using the `wrapped format`, e.g.:
 ```json
@@ -93,8 +98,8 @@ For such cases, we recommend using the `wrapped format`, e.g.:
     "__hd_wrapped_data_object__": "DATAFRAME",
     "__metadata__": {
         "ref_data_frequency": {
-            "a": 1h,
-            "b": 1h
+            "a": "1h",
+            "b": "1h"
         }
     },
     "__data__": {
@@ -114,22 +119,21 @@ For such cases, we recommend using the `wrapped format`, e.g.:
             "0": "2019-08-01T01:00:00.000Z",
             "1": "2019-08-01T02:00:00.000Z",
             "2": "2019-08-01T01:00:00.000Z",
-            "2": "2019-08-01T02:00:00.000Z"
+            "3": "2019-08-01T02:00:00.000Z"
         }
     }
 }
 ```
 
 
-**Tip**: Having a Pandas DataFrame variable `df` (e.g. in a jupyter notebook) with these 3 columns you can obtain this format by calling the `to_json` method with `orient="columns", date_format="iso"`:
-```python
-print(df.to_json(orient="columns", date_format="iso", indent=2))
-```
+
 
 ### [Generic Rest Adapter](../adapter_system/generic_rest_adapters/web_service_interface.md)
-The generic rest adapter provides functionalities to load ("get") and send ("post") MultiTSFrames from the hd-instance using the two functions [`post_multitsframe`](../../runtime/hetdesrun/adapters/generic_rest/send_multitsframe.py), and [`load_framelike_data`](../../runtime/hetdesrun/adapters/generic_rest/load_multitsframe.py)
+The generic rest adapter provides functionalities to receive from and send to the hd-instance MultiTSFrames using the two functions [`post_multitsframe`](../../runtime/hetdesrun/adapters/generic_rest/send_multitsframe.py), and [`load_framelike_data`](../../runtime/hetdesrun/adapters/generic_rest/load_multitsframe.py)
 
-Sending MultiTSFrames requires that the output Pandas DataFrame of a workflow/component passes several validations:
+Receiving a MultiTSFrames from the hd-instance requires that the output of the workflow/component
+(defined as pandas.DataFrame in the code and MultiTSFrame in the hetida-designer)
+passes several validations:
 - column "timestamp" has no missing entries and a dtype of pandas.DatetimeTZDtype with timezone UTC
 - column "metric" has no missing entries
 - at least one additional column is defined.

--- a/docs/datatypes/multitsframes.md
+++ b/docs/datatypes/multitsframes.md
@@ -63,7 +63,7 @@ In the documentation of the workflow and components the convention is to write *
 ```
 
 ## External: Adapter System
-### Manual Input / Direct Provisioning [Link](../adapter_system/manual_input.md)
+### Manual Input / Direct Provisioning [[Link]](../adapter_system/manual_input.md)
 To define a MultiTSFrame a json of the following format can be defined:
 
 ```json
@@ -128,7 +128,7 @@ For such cases, we recommend using the `wrapped format`, e.g.:
 
 
 
-### Generic Rest Adapter [Link](../adapter_system/generic_rest_adapters/web_service_interface.md)
+### Generic Rest Adapter [[Link]](../adapter_system/generic_rest_adapters/web_service_interface.md)
 The generic rest adapter provides functionalities to receive from and send to the hd-instance MultiTSFrames using the two functions [`post_multitsframe`](../../runtime/hetdesrun/adapters/generic_rest/send_multitsframe.py), and [`load_framelike_data`](../../runtime/hetdesrun/adapters/generic_rest/load_multitsframe.py)
 
 Receiving a MultiTSFrames from the hd-instance requires that the output of the workflow/component

--- a/docs/datatypes/multitsframes.md
+++ b/docs/datatypes/multitsframes.md
@@ -53,7 +53,7 @@ Within workflows and components the MultiTSFrame object is a pandas.DataFrame fo
 - "timestamp" column with timestamp information,
 - "additional" column, mostly named value.
 
-Note that Pandas will handle a column build from values of differing types as dtype `object` and this may negatively impact efficiency / performance).
+Note that Pandas will handle a column build from values of differing types as dtype `object` and this may negatively impact efficiency / performance.
 
 In contrast to pandas.Series the index of a MultiTSFrame should be considered irrelevant since timestamp information is in the "timestamp" column. When manipulating MultiTSFrame Pandas DataFrames you should ensure that the resulting index is duplicate-free. Ideally a generic integer index.
 
@@ -127,7 +127,7 @@ print(df.to_json(orient="columns", date_format="iso", indent=2))
 ```
 
 ### [Generic Rest Adapter](../adapter_system/generic_rest_adapters/web_service_interface.md)
-The generic rest adapter provides functionalities to load and send MultiTSFrames from the hd-instance using the two functions [`post_multitsframe`](../../runtime/hetdesrun/adapters/generic_rest/send_multitsframe.py), and [`load_framelike_data`](../../runtime/hetdesrun/adapters/generic_rest/load_multitsframe.py)
+The generic rest adapter provides functionalities to load ("get") and send ("post") MultiTSFrames from the hd-instance using the two functions [`post_multitsframe`](../../runtime/hetdesrun/adapters/generic_rest/send_multitsframe.py), and [`load_framelike_data`](../../runtime/hetdesrun/adapters/generic_rest/load_multitsframe.py)
 
 Sending MultiTSFrames requires that the output Pandas DataFrame of a workflow/component passes several validations:
 - column "timestamp" has no missing entries and a dtype of pandas.DatetimeTZDtype with timezone UTC

--- a/docs/datatypes/multitsframes.md
+++ b/docs/datatypes/multitsframes.md
@@ -1,0 +1,58 @@
+
+# MULTITSFRAME
+In general, a MultiTSframe is timeseries format, especially suitable for multiple timeseries, using the [long format](https://www.thedataschool.co.uk/luke-bennett/long-vs-wide-data-tables/#:~:text=Data%20tables%20are%20often%20referred,(making%20the%20table%20wider)).
+
+A main advantage of the long-format is that it is very storage-efficient in case that multiple timeseries do not have the same timestamps.
+
+A MultiTSFrame must have at least three columns, where to must be names with "timestamp" (datetime, no missing entries allowed) and "metric" (string, no missing entries allowed). Per convention the third column is often named with "value" as many default-componets assume this column name.
+
+In case the MultiTSFrame contains timeseries where the timestamps are always the same, e.g., when a series is aggregated for a certain frequency using different functions, it might be useful to return a MultiTSFrame with additional columns. This is a special case and should only be applied, when it is clear that the stored timeseries will never have different timestamps.
+
+## Internal: Workflow & Components
+Within workflows and components the MultiTSFrame object is a pandas.DataFrame following certain conventions:
+- "metric" column with string and no missing data,
+- "timestamp" column with timestamp information,
+- "additional" column, mostly named value.
+
+ If the value column contains several entries with varying dtype, the dtype of the column is `object`. (Note that this unspecific dtype hinders efficiency). In conrast to pandas.Series the index of a MultiTSFrame is usually defined with integers starting from zero.
+
+In the documentation of the workflow and components the convention is to write **MultiTSFrame**, e.g.:
+- mutiple_timeseries (MultiTSFrame): This is an example for the documentation of an input/output with the type MultiTSFrame
+
+## External: Adapter System
+### Manual Input / Direct Provisioning
+To define a MultiTSFrame a json of the following format can be defined:
+
+```json
+{
+    "value": [
+        1,
+        1.2,
+        0.5
+    ],
+    "metric": [
+        "a",
+        "b",
+        "c"
+    ],
+    "timestamp": [
+        "2019-08-01T15:45:36.000Z",
+        "2019-08-01T15:48:36.000Z",
+        "2019-08-01T15:42:36.000Z"
+    ]
+}
+```
+Tip: Having a Pandas DataFrame variable `df` (e.g. in a jupyter notebook) with these 3 columns you can obtain this format by calling the `to_json` method with `orient="columns", date_format="iso"`:
+```python
+print(df.to_json(orient="columns", date_format="iso", indent=2))
+```
+
+### Generic Rest Adapter
+The generic rest adapter provides functionalities to load and send MultiTSFrames from the hd-instance using the two functions [`post_multitsframe`](../../runtime/hetdesrun/adapters/generic_rest/send_multitsframe.py), and [`load_framelike_data`](../../runtime/hetdesrun/adapters/generic_rest/load_multitsframe.py)
+
+Sending MultiTSFrames requires that the output of a workflow/component passes several validations:
+-  column "timestamp" has no missing entries and a dtype of pandas.DatetimeTZDtype with timezone UTC
+- column "metric" has no missing entries
+- at least one additional column is defined.
+
+Loading MultiTSFrames requires that the send object is readable via `pd.read_json`.

--- a/docs/datatypes/multitsframes.md
+++ b/docs/datatypes/multitsframes.md
@@ -4,7 +4,7 @@ In general, a MultiTSframe is timeseries format, especially suitable for multipl
 
 A main advantage of the long-format is that it is very storage-efficient in case that multiple timeseries do not have the same timestamps.
 
-A MultiTSFrame must have at least three columns, where to must be names with "timestamp" (datetime, no missing entries allowed) and "metric" (string, no missing entries allowed). Per convention the third column is often named with "value" as many default-componets assume this column name.
+A MultiTSFrame must have at least three columns, where two must be names with "timestamp" (datetime, no missing entries allowed) and "metric" (string, no missing entries allowed). Per convention the third column is often named with "value" as many default-components assume this column name.
 
 In case the MultiTSFrame contains timeseries where the timestamps are always the same, e.g., when a series is aggregated for a certain frequency using different functions, it might be useful to return a MultiTSFrame with additional columns. This is a special case and should only be applied, when it is clear that the stored timeseries will never have different timestamps.
 
@@ -14,13 +14,13 @@ Within workflows and components the MultiTSFrame object is a pandas.DataFrame fo
 - "timestamp" column with timestamp information,
 - "additional" column, mostly named value.
 
- If the value column contains several entries with varying dtype, the dtype of the column is `object`. (Note that this unspecific dtype hinders efficiency). In conrast to pandas.Series the index of a MultiTSFrame is usually defined with integers starting from zero.
+ If the value column contains several entries with varying dtype, the dtype of the column is `object`. (Note that this unspecific dtype hinders efficiency). In contrast to pandas.Series the index of a MultiTSFrame is usually defined with integers starting from zero.
 
 In the documentation of the workflow and components the convention is to write **MultiTSFrame**, e.g.:
 - mutiple_timeseries (MultiTSFrame): This is an example for the documentation of an input/output with the type MultiTSFrame
 
 ## External: Adapter System
-### Manual Input / Direct Provisioning
+### [Manual Input / Direct Provisioning](../adapter_system/manual_input.md)
 To define a MultiTSFrame a json of the following format can be defined:
 
 ```json
@@ -47,11 +47,11 @@ Tip: Having a Pandas DataFrame variable `df` (e.g. in a jupyter notebook) with t
 print(df.to_json(orient="columns", date_format="iso", indent=2))
 ```
 
-### Generic Rest Adapter
+### [Generic Rest Adapter](../adapter_system/generic_rest_adapters/web_service_interface.md)
 The generic rest adapter provides functionalities to load and send MultiTSFrames from the hd-instance using the two functions [`post_multitsframe`](../../runtime/hetdesrun/adapters/generic_rest/send_multitsframe.py), and [`load_framelike_data`](../../runtime/hetdesrun/adapters/generic_rest/load_multitsframe.py)
 
 Sending MultiTSFrames requires that the output of a workflow/component passes several validations:
--  column "timestamp" has no missing entries and a dtype of pandas.DatetimeTZDtype with timezone UTC
+- column "timestamp" has no missing entries and a dtype of pandas.DatetimeTZDtype with timezone UTC
 - column "metric" has no missing entries
 - at least one additional column is defined.
 

--- a/docs/datatypes/multitsframes.md
+++ b/docs/datatypes/multitsframes.md
@@ -1,12 +1,27 @@
 
 # MULTITSFRAME
-In general, a MultiTSframe is timeseries format, especially suitable for multiple timeseries, using the [long format](https://www.thedataschool.co.uk/luke-bennett/long-vs-wide-data-tables/#:~:text=Data%20tables%20are%20often%20referred,(making%20the%20table%20wider)).
 
-A main advantage of the long-format is that it is very storage-efficient in case that multiple timeseries do not have the same timestamps.
+MultiTSFrames represents multiple timeseries (of same dimension) data with non-necessarily common timestamps.
 
-A MultiTSFrame must have at least three columns, where two must be names with "timestamp" (datetime, no missing entries allowed) and "metric" (string, no missing entries allowed). Per convention the third column is often named with "value" as many default-components assume this column name.
+Data is stored in records, one per metric per timestamp where this metric has value(s), i.e. in "long format", e.g.
 
+timestamp, metric, value
+2024-12-01T01:00:00+00:00
+....
+
+
+This is in contrast to "wide format" where each metric is its own column.
+
+A main advantage of the long-format is that it is more storage-efficient in case that multiple timeseries do not have the same timestamps.
+
+A MultiTSFrame must have at least three columns: 
+* a "timestamp" column (datetime, no missing entries allowed)
+* a "metric" column (string, no missing entries allowed)
+* at least one value column: Per convention the third column is often named "value". Many base components assume only the three columns "timestamp", "metric" and "value".
+
+TODO: reformulate "multi-dimensional"
 In case the MultiTSFrame contains timeseries where the timestamps are always the same, e.g., when a series is aggregated for a certain frequency using different functions, it might be useful to return a MultiTSFrame with additional columns. This is a special case and should only be applied, when it is clear that the stored timeseries will never have different timestamps.
+
 
 ## Internal: Workflow & Components
 Within workflows and components the MultiTSFrame object is a pandas.DataFrame following certain conventions:
@@ -14,7 +29,9 @@ Within workflows and components the MultiTSFrame object is a pandas.DataFrame fo
 - "timestamp" column with timestamp information,
 - "additional" column, mostly named value.
 
- If the value column contains several entries with varying dtype, the dtype of the column is `object`. (Note that this unspecific dtype hinders efficiency). In contrast to pandas.Series the index of a MultiTSFrame is usually defined with integers starting from zero.
+Note that Pandas will handle a column build from values of differing types as dtype `object` and this may negatively impact efficiency / performance).
+
+In contrast to pandas.Series the index of a MultiTSFrame should be considered irrelevant since timestamp information is in the "timestamp" column. When manipulating MultiTSFrame Pandas DataFrames you should ensure that the resulting index is duplicate-free. Ideally a generic integer index.
 
 In the documentation of the workflow and components the convention is to write **MultiTSFrame**, e.g.:
 - mutiple_timeseries (MultiTSFrame): This is an example for the documentation of an input/output with the type MultiTSFrame
@@ -42,7 +59,10 @@ To define a MultiTSFrame a json of the following format can be defined:
     ]
 }
 ```
-Tip: Having a Pandas DataFrame variable `df` (e.g. in a jupyter notebook) with these 3 columns you can obtain this format by calling the `to_json` method with `orient="columns", date_format="iso"`:
+
+TODO: mention wrapped format!
+
+**Tip**: Having a Pandas DataFrame variable `df` (e.g. in a jupyter notebook) with these 3 columns you can obtain this format by calling the `to_json` method with `orient="columns", date_format="iso"`:
 ```python
 print(df.to_json(orient="columns", date_format="iso", indent=2))
 ```
@@ -50,9 +70,7 @@ print(df.to_json(orient="columns", date_format="iso", indent=2))
 ### [Generic Rest Adapter](../adapter_system/generic_rest_adapters/web_service_interface.md)
 The generic rest adapter provides functionalities to load and send MultiTSFrames from the hd-instance using the two functions [`post_multitsframe`](../../runtime/hetdesrun/adapters/generic_rest/send_multitsframe.py), and [`load_framelike_data`](../../runtime/hetdesrun/adapters/generic_rest/load_multitsframe.py)
 
-Sending MultiTSFrames requires that the output of a workflow/component passes several validations:
+Sending MultiTSFrames requires that the output Pandas DataFrame of a workflow/component passes several validations:
 - column "timestamp" has no missing entries and a dtype of pandas.DatetimeTZDtype with timezone UTC
 - column "metric" has no missing entries
 - at least one additional column is defined.
-
-Loading MultiTSFrames requires that the send object is readable via `pd.read_json`.

--- a/docs/datatypes/multitsframes.md
+++ b/docs/datatypes/multitsframes.md
@@ -63,7 +63,7 @@ In the documentation of the workflow and components the convention is to write *
 ```
 
 ## External: Adapter System
-### [Manual Input / Direct Provisioning](../adapter_system/manual_input.md)
+### Manual Input / Direct Provisioning [Link](../adapter_system/manual_input.md)
 To define a MultiTSFrame a json of the following format can be defined:
 
 ```json
@@ -128,7 +128,7 @@ For such cases, we recommend using the `wrapped format`, e.g.:
 
 
 
-### [Generic Rest Adapter](../adapter_system/generic_rest_adapters/web_service_interface.md)
+### Generic Rest Adapter [Link](../adapter_system/generic_rest_adapters/web_service_interface.md)
 The generic rest adapter provides functionalities to receive from and send to the hd-instance MultiTSFrames using the two functions [`post_multitsframe`](../../runtime/hetdesrun/adapters/generic_rest/send_multitsframe.py), and [`load_framelike_data`](../../runtime/hetdesrun/adapters/generic_rest/load_multitsframe.py)
 
 Receiving a MultiTSFrames from the hd-instance requires that the output of the workflow/component

--- a/docs/datatypes/multitsframes.md
+++ b/docs/datatypes/multitsframes.md
@@ -1,7 +1,7 @@
 
 # MULTITSFRAME
 
-MultiTSFrames represents multiple timeseries (of same dimension) data with non-necessarily common timestamps.
+A MultiTSFrame represents multiple timeseries (of same dimension) data with non-necessarily common timestamps.
 
 Data is stored in records, one per metric per timestamp where this metric has value(s), i.e. in "long format".
 This is in contrast to "wide format" where each metric is its own column. A main advantage of the long-format is
@@ -35,23 +35,33 @@ that it is more storage-efficient in case that multiple timeseries do not have t
 A MultiTSFrame must have at least three columns:
 * a "timestamp" column (datetime, no missing entries allowed)
 * a "metric" column (string, no missing entries allowed)
-* at least one value column: Per convention the third column is often named "value". Many base components assume only the three columns "timestamp", "metric" and "value".
+* at least one value column: Per convention the third column is often named "value". Note that many base components operating on MultiTsFrames assume only the three columns "timestamp", "metric" and "value".
 
-A special case of a MultiTSFrame are multi-dimensional timeseries . For example, such a multi-dimensional timeseries
-is a climate station that measures temperature, precipitation and air pressure at the same time. In this case, the MultiTSFrame contains mutiple timeseries where the timestamps are always the same. Hereby it is useful to return a MultiTSFrame with additional columns. An example for multi-dimensional timeseries of two climate stations using a multiTSFrame with additonal columns is shown below.
+A MultiTSFrame can contain multi-dimensional timeseries data simply by having more than one value column. This implies that dimensions should agree for all metrics.
 
-| timestamp                 |  metric     |temp |prec |  pres |
-| :-----------------------: | :---------: | :-: | :-: | :---: |
-| 2024-12-01T01:00:00+00:00 |  station A  | 0.2 | 0.0 | 1014. |
-| 2024-12-01T02:00:00+00:00 |  station A  | 0.3 | 0.2 | 1015. |
-| 2024-12-01T01:01:00+00:00 |  station B  | 0.1 | 0.0 | 1013. |
+As an example consider a measurement by drones where location of measurement is relevant:
+
+| timestamp                 |  metric            | value | latitude            | longitude         |
+| :-----------------------: | :----------------: | :---: | :-----------------: | :---------------: |
+| 2024-12-01T01:00:00+00:00 |  drone_A.temp      |  10.2 |   51.43462264339895 | 7.030261299552767 |
+| 2024-12-01T01:00:00+00:00 |  drone_A.pressure  |  0.47 |   51.43462264339895 | 7.030261299552767 |
+| 2024-12-01T01:00:06+00:00 |  drone_A.temp      |  10.1 |   51.43462271146983 | 7.030265004120332 |
+| 2024-12-01T01:00:00+00:00 |  drone_B.temp      |   8.7 |   51.43952210110222 | 7.032115169871234 |
+| 2024-12-01T01:00:05+00:00 |  drone_B.temp      |   8.6 |   51.43952228945781 | 7.032115457891023 |
+
+Or stock share trade events where price and number of trades shares is necessary:
+
+| timestamp                 |  metric     | price    | number |
+| :-----------------------: | :---------: | :------: | :----: |
+| 2024-11-30T07:35:00+00:00 |  MSFT       |    409.6 |    -10 |
+| 2024-12-02T15:16:12+00:00 |  AMZN       |   200.65 |      3 |
 
 
 ## Internal: Workflow & Components
 Within workflows and components the MultiTSFrame object is a pandas.DataFrame following certain conventions:
 - "metric" column with string and no missing data,
 - "timestamp" column with timestamp information,
-- "additional" column, mostly named value.
+- additional value columns (at least one), often exactly one named "value".
 
 Note that Pandas will handle a column build from values of differing types as dtype `object` and this may negatively impact efficiency / performance.
 
@@ -64,7 +74,7 @@ In the documentation of the workflow and components the convention is to write *
 
 ## External: Adapter System
 ### Manual Input / Direct Provisioning [[Link]](../adapter_system/manual_input.md)
-To define a MultiTSFrame a json of the following format can be defined:
+A simple json representation of a MultiTSFrame is the following format:
 
 ```json
 {
@@ -125,15 +135,8 @@ For such cases, we recommend using the `wrapped format`, e.g.:
 }
 ```
 
-
-
-
 ### Generic Rest Adapter [[Link]](../adapter_system/generic_rest_adapters/web_service_interface.md)
-The generic rest adapter provides functionalities to receive from and send to the hd-instance MultiTSFrames using the two functions [`post_multitsframe`](../../runtime/hetdesrun/adapters/generic_rest/send_multitsframe.py), and [`load_framelike_data`](../../runtime/hetdesrun/adapters/generic_rest/load_multitsframe.py)
-
-Receiving a MultiTSFrames from the hd-instance requires that the output of the workflow/component
-(defined as pandas.DataFrame in the code and MultiTSFrame in the hetida-designer)
-passes several validations:
+Sending a MultiTSFrames from a hetida designer workflow/component output to a generic Rest adapter sink of type MULTITSFRAME requires that the output pandas.DataFrame object passes several validations:
 - column "timestamp" has no missing entries and a dtype of pandas.DatetimeTZDtype with timezone UTC
 - column "metric" has no missing entries
 - at least one additional column is defined.

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -33,6 +33,9 @@ Further information about developing, deploying, connecting, using and running h
 
 - [Enabling OpenID Connect Authentication](enabling_openidconnect_auth.md)
 
+## Overview about available datatypes
+- [multitsframes](./datatypes/multitsframes.md)
+
 ## Adapter System
 
 - [Introduction to the Adapter System](./adapter_system/intro.md)

--- a/runtime/hetdesrun/adapters/generic_rest/send_multitsframe.py
+++ b/runtime/hetdesrun/adapters/generic_rest/send_multitsframe.py
@@ -13,14 +13,16 @@ from hetdesrun.webservice.config import get_config
 
 
 def multitsframe_to_list_of_dicts(df: pd.DataFrame) -> list[dict]:
-    """function that
-    (1) validates form of the dataframe (columns and missing values)
-    (2) replaces np.nan with None
-    (3) returns a serialized object
+    """Prepares serialization by converting rows into json-serializable dicts
 
-    Note: As the content of the given pandas.DataFrame should not be
-    modified (exception is np.nan to None) we do not use the
-    pydantic class PydanticMultiTimeseriesPandasDataFrame in hdutils.
+    * validates form of the dataframe (columns and missing values)
+    * np.nan -> None
+    * datetimes are enforced to be UTC and are converted to zulu-format strings
+
+    Note: The given pandas.DataFrame is not modified. We cannot use
+    PydanticMultiTimeseriesPandasDataFrame here since this would mutate
+    the df object.
+    
     However, the applied validations are mostly the same.
     """
 

--- a/runtime/hetdesrun/adapters/generic_rest/send_multitsframe.py
+++ b/runtime/hetdesrun/adapters/generic_rest/send_multitsframe.py
@@ -8,12 +8,22 @@ from httpx import AsyncClient
 
 from hetdesrun.adapters.exceptions import AdapterOutputDataError
 from hetdesrun.adapters.generic_rest.send_framelike import post_framelike_records
-from hetdesrun.datatypes import MULTITSFRAME_COLUMN_NAMES
 from hetdesrun.models.data_selection import FilteredSink
 from hetdesrun.webservice.config import get_config
 
 
 def multitsframe_to_list_of_dicts(df: pd.DataFrame) -> list[dict]:
+    """function that
+    (1) validates form of the dataframe (columns and missing values)
+    (2) replaces np.nan with None
+    (3) returns a serialized object
+
+    Note: As the content of the given pandas.DataFrame should not be
+    modified (exception is np.nan to None) we do not use the
+    pydantic class PydanticMultiTimeseriesPandasDataFrame in hdutils.
+    However, the applied validations are mostly the same.
+    """
+
     if not isinstance(df, pd.DataFrame):
         raise AdapterOutputDataError(
             "Did not receive Pandas DataFrame as expected from workflow output."
@@ -23,12 +33,16 @@ def multitsframe_to_list_of_dicts(df: pd.DataFrame) -> list[dict]:
     if len(df) == 0:
         return []
 
-    if set(df.columns).intersection(set(MULTITSFRAME_COLUMN_NAMES)) != set(
-        MULTITSFRAME_COLUMN_NAMES
-    ):
-        raise AdapterOutputDataError(
-            f"Received Pandas Dataframe has column names { {*df.columns} } that don't match "
-            f"the column names required for a MultiTSFrame { {*MULTITSFRAME_COLUMN_NAMES} }."
+    if len(df.columns) < 3:
+        raise ValueError(
+            "MultiTSFrame requires at least 3 columns: metric, timestamp"
+            f" and at least one additional columns. Only found { {*df.columns} }"
+        )
+
+    if not ({"metric", "timestamp"}.issubset(set(df.columns))):
+        raise ValueError(
+            f"The column names { {*df.columns} } don't contain required columns"
+            ' "timestamp" and "metric" for a MultiTSFrame.'
         )
 
     if df["metric"].isna().any():

--- a/runtime/hetdesrun/adapters/generic_rest/send_multitsframe.py
+++ b/runtime/hetdesrun/adapters/generic_rest/send_multitsframe.py
@@ -22,7 +22,7 @@ def multitsframe_to_list_of_dicts(df: pd.DataFrame) -> list[dict]:
     Note: The given pandas.DataFrame is not modified. We cannot use
     PydanticMultiTimeseriesPandasDataFrame here since this would mutate
     the df object.
-    
+
     However, the applied validations are mostly the same.
     """
 

--- a/runtime/hetdesrun/adapters/generic_rest/send_multitsframe.py
+++ b/runtime/hetdesrun/adapters/generic_rest/send_multitsframe.py
@@ -34,13 +34,13 @@ def multitsframe_to_list_of_dicts(df: pd.DataFrame) -> list[dict]:
         return []
 
     if len(df.columns) < 3:
-        raise ValueError(
+        raise AdapterOutputDataError(
             "MultiTSFrame requires at least 3 columns: metric, timestamp"
             f" and at least one additional columns. Only found { {*df.columns} }"
         )
 
     if not ({"metric", "timestamp"}.issubset(set(df.columns))):
-        raise ValueError(
+        raise AdapterOutputDataError(
             f"The column names { {*df.columns} } don't contain required columns"
             ' "timestamp" and "metric" for a MultiTSFrame.'
         )

--- a/runtime/hetdesrun/adapters/generic_rest/send_multitsframe.py
+++ b/runtime/hetdesrun/adapters/generic_rest/send_multitsframe.py
@@ -23,12 +23,10 @@ def multitsframe_to_list_of_dicts(df: pd.DataFrame) -> list[dict]:
     if len(df) == 0:
         return []
 
-    if set(df.columns) != set(MULTITSFRAME_COLUMN_NAMES):
-        column_names_string = ", ".join(df.columns)
-        multitsframe_column_names_string = ", ".join(MULTITSFRAME_COLUMN_NAMES)
+    if set(df.columns).intersection(set(MULTITSFRAME_COLUMN_NAMES)) != set(MULTITSFRAME_COLUMN_NAMES):
         raise AdapterOutputDataError(
-            f"Received Pandas Dataframe has column names {column_names_string} that don't match "
-            f"the column names required for a MultiTSFrame {multitsframe_column_names_string}."
+            f"Received Pandas Dataframe has column names { {*df.columns} } that don't match "
+            f"the column names required for a MultiTSFrame { {*MULTITSFRAME_COLUMN_NAMES} }."
         )
 
     if df["metric"].isna().any():

--- a/runtime/hetdesrun/adapters/generic_rest/send_multitsframe.py
+++ b/runtime/hetdesrun/adapters/generic_rest/send_multitsframe.py
@@ -23,7 +23,9 @@ def multitsframe_to_list_of_dicts(df: pd.DataFrame) -> list[dict]:
     if len(df) == 0:
         return []
 
-    if set(df.columns).intersection(set(MULTITSFRAME_COLUMN_NAMES)) != set(MULTITSFRAME_COLUMN_NAMES):
+    if set(df.columns).intersection(set(MULTITSFRAME_COLUMN_NAMES)) != set(
+        MULTITSFRAME_COLUMN_NAMES
+    ):
         raise AdapterOutputDataError(
             f"Received Pandas Dataframe has column names { {*df.columns} } that don't match "
             f"the column names required for a MultiTSFrame { {*MULTITSFRAME_COLUMN_NAMES} }."

--- a/runtime/tests/generic_rest_adapter/test_send_multitsframe.py
+++ b/runtime/tests/generic_rest_adapter/test_send_multitsframe.py
@@ -256,3 +256,34 @@ async def test_end_to_end_send_only_multitsframe_data() -> None:
                 {"outp_9": mtsf_9},
                 adapter_key="test_end_to_end_send_only_multitsframe_data",
             )
+
+@pytest.mark.asyncio
+async def test_send_multitsframe_extra_columns() -> None:
+    post_mock = mock.AsyncMock(return_value=mock.Mock(status_code=200))
+
+    with (
+        mock.patch(  # noqa: SIM117
+            "hetdesrun.adapters.generic_rest.send_framelike.get_generic_rest_adapter_base_url",
+            return_value="https://hetida.de",
+        ),
+        mock.patch(
+            "hetdesrun.adapters.generic_rest.send_multitsframe.AsyncClient.post",
+            new=post_mock,
+        ),
+    ):
+
+        mts = pd.DataFrame(
+            {
+                "metric": ["a"],
+                "timestamp": [pd.Timestamp("2019-08-01T15:45:36Z")],
+                "value": [1.0],
+                "min": [0.0]
+            })
+
+        await send_data(
+            {"outp": FilteredSink(ref_id="sink_id_8", type="multitsframe")},
+            {"outp": mts},
+            adapter_key="test_end_to_end_send_only_multitsframe_data"
+        )
+
+        assert post_mock.called  # we got through to actually posting!

--- a/runtime/tests/generic_rest_adapter/test_send_multitsframe.py
+++ b/runtime/tests/generic_rest_adapter/test_send_multitsframe.py
@@ -11,280 +11,313 @@ from hetdesrun.adapters.generic_rest.load_framelike import decode_attributes
 from hetdesrun.models.data_selection import FilteredSink
 
 
-@pytest.mark.asyncio
-async def test_end_to_end_send_only_multitsframe_data() -> None:
-    post_mock = mock.AsyncMock(return_value=mock.Mock(status_code=200))
+@pytest.fixture
+def mocked_url():
+    with mock.patch(  # noqa: SIM117
+        "hetdesrun.adapters.generic_rest.send_framelike.get_generic_rest_adapter_base_url",
+        return_value="https://hetida.de",
+    ) as _fixutre:
+        yield _fixutre
 
-    with (
-        mock.patch(  # noqa: SIM117
-            "hetdesrun.adapters.generic_rest.send_framelike.get_generic_rest_adapter_base_url",
-            return_value="https://hetida.de",
-        ),
-        mock.patch(
-            "hetdesrun.adapters.generic_rest.send_multitsframe.AsyncClient.post",
-            new=post_mock,
-        ),
-    ):
-        mtsf_1 = pd.DataFrame(
-            {
-                "metric": ["a", "b", "c", "a", "b", "c", "a", "b", "c"],
-                "timestamp": [
-                    pd.Timestamp("2019-08-01T15:45:36.000Z"),
-                    pd.Timestamp("2019-08-01T15:45:37.000Z"),
-                    pd.Timestamp("2019-08-01T15:45:37.000Z"),
-                    pd.Timestamp("2019-08-01T15:45:46.000Z"),
-                    pd.Timestamp("2019-08-01T15:45:46.000Z"),
-                    pd.Timestamp("2019-08-01T15:45:47.000Z"),
-                    pd.Timestamp("2019-08-01T15:45:56.000Z"),
-                    pd.Timestamp("2019-08-01T15:45:57.000Z"),
-                    pd.Timestamp("2019-08-01T15:45:58.000Z"),
-                ],
-                "value": [1.0, 1.2, 0.5, 1.9, 1.3, 0.2, 1.5, 1.7, 0.1],
-            }
-        )
-        mtsf_1.attrs = {
-            "from": "2019-08-01T15:45:30.000Z",
-            "to": "2019-08-01T15:46:00.000Z",
+
+@pytest.fixture()
+def mocked_api():
+    post_mock = mock.AsyncMock(return_value=mock.Mock(status_code=200))
+    with mock.patch(
+        "hetdesrun.adapters.generic_rest.send_multitsframe.AsyncClient.post",
+        new=post_mock,
+    ) as _fixutre:
+        yield _fixutre
+
+
+@pytest.mark.asyncio
+async def test_end_to_end_send_only_multitsframe_data(mocked_url, mocked_api) -> None:
+    mtsf_1 = pd.DataFrame(
+        {
+            "metric": ["a", "b", "c", "a", "b", "c", "a", "b", "c"],
+            "timestamp": [
+                pd.Timestamp("2019-08-01T15:45:36.000Z"),
+                pd.Timestamp("2019-08-01T15:45:37.000Z"),
+                pd.Timestamp("2019-08-01T15:45:37.000Z"),
+                pd.Timestamp("2019-08-01T15:45:46.000Z"),
+                pd.Timestamp("2019-08-01T15:45:46.000Z"),
+                pd.Timestamp("2019-08-01T15:45:47.000Z"),
+                pd.Timestamp("2019-08-01T15:45:56.000Z"),
+                pd.Timestamp("2019-08-01T15:45:57.000Z"),
+                pd.Timestamp("2019-08-01T15:45:58.000Z"),
+            ],
+            "value": [1.0, 1.2, 0.5, 1.9, 1.3, 0.2, 1.5, 1.7, 0.1],
         }
-        mtsf_2 = pd.DataFrame(
-            {
-                "metric": ["a", "d", "e", "a", "a", "e"],
-                "timestamp": [
-                    pd.Timestamp("2019-08-01T15:45:36.000Z"),
-                    pd.Timestamp("2019-08-01T15:45:37.000Z"),
-                    pd.Timestamp("2019-08-01T15:45:37.000Z"),
-                    pd.Timestamp("2019-08-01T15:45:46.000Z"),
-                    pd.Timestamp("2019-08-01T15:45:56.000Z"),
-                    pd.Timestamp("2019-08-01T15:45:57.000Z"),
-                ],
-                "value": [1.0, np.nan, None, 1.9, 1.5, "text"],
-            }
-        )
+    )
+    mtsf_1.attrs = {
+        "from": "2019-08-01T15:45:30.000Z",
+        "to": "2019-08-01T15:46:00.000Z",
+    }
+    mtsf_2 = pd.DataFrame(
+        {
+            "metric": ["a", "d", "e", "a", "a", "e"],
+            "timestamp": [
+                pd.Timestamp("2019-08-01T15:45:36.000Z"),
+                pd.Timestamp("2019-08-01T15:45:37.000Z"),
+                pd.Timestamp("2019-08-01T15:45:37.000Z"),
+                pd.Timestamp("2019-08-01T15:45:46.000Z"),
+                pd.Timestamp("2019-08-01T15:45:56.000Z"),
+                pd.Timestamp("2019-08-01T15:45:57.000Z"),
+            ],
+            "value": [1.0, np.nan, None, 1.9, 1.5, "text"],
+        }
+    )
+    await send_data(
+        {
+            "outp_1": FilteredSink(
+                ref_id="sink_id_1",
+                type="multitsframe",
+                filters={"filter_key_1": "filter_value_1"},
+            ),
+            "outp_2": FilteredSink(
+                ref_id="sink_id_2",
+                type=ExternalType.MULTITSFRAME,
+                filters={"filter_key_2": "filter_value_2"},
+            ),
+            "outp_3": FilteredSink(
+                ref_id="sink_id_3",
+                type=ExternalType.MULTITSFRAME,
+                filters={"filter_key_3": "filter_value_3"},
+            ),
+        },
+        {"outp_1": mtsf_1, "outp_2": mtsf_2, "outp_3": pd.DataFrame([])},
+        adapter_key="test_end_to_end_send_only_multitsframe_data",
+    )
+    assert mocked_api.called  # we got through to actually posting!
+    _, _, kwargs_1 = mocked_api.mock_calls[0]
+    assert kwargs_1["params"] == [
+        ("id", "sink_id_1"),
+        ("filter_key_1", "filter_value_1"),
+    ]
+    assert kwargs_1["json"] == [
+        {
+            "timestamp": "2019-08-01T15:45:36.000000000Z",
+            "metric": "a",
+            "value": 1.0,
+        },
+        {
+            "timestamp": "2019-08-01T15:45:37.000000000Z",
+            "metric": "b",
+            "value": 1.2,
+        },
+        {
+            "timestamp": "2019-08-01T15:45:37.000000000Z",
+            "metric": "c",
+            "value": 0.5,
+        },
+        {
+            "timestamp": "2019-08-01T15:45:46.000000000Z",
+            "metric": "a",
+            "value": 1.9,
+        },
+        {
+            "timestamp": "2019-08-01T15:45:46.000000000Z",
+            "metric": "b",
+            "value": 1.3,
+        },
+        {
+            "timestamp": "2019-08-01T15:45:47.000000000Z",
+            "metric": "c",
+            "value": 0.2,
+        },
+        {
+            "timestamp": "2019-08-01T15:45:56.000000000Z",
+            "metric": "a",
+            "value": 1.5,
+        },
+        {
+            "timestamp": "2019-08-01T15:45:57.000000000Z",
+            "metric": "b",
+            "value": 1.7,
+        },
+        {
+            "timestamp": "2019-08-01T15:45:58.000000000Z",
+            "metric": "c",
+            "value": 0.1,
+        },
+    ]
+    assert "Data-Attributes" in kwargs_1["headers"]
+    received_attrs = decode_attributes(kwargs_1["headers"]["Data-Attributes"])
+    assert received_attrs["from"] == "2019-08-01T15:45:30.000Z"
+    assert received_attrs["to"] == "2019-08-01T15:46:00.000Z"
+
+    _, _, kwargs_2 = mocked_api.mock_calls[1]
+    assert kwargs_2["params"] == [
+        ("id", "sink_id_2"),
+        ("filter_key_2", "filter_value_2"),
+    ]
+    assert kwargs_2["json"] == [
+        {
+            "timestamp": "2019-08-01T15:45:36.000000000Z",
+            "metric": "a",
+            "value": 1.0,
+        },
+        {
+            "timestamp": "2019-08-01T15:45:37.000000000Z",
+            "metric": "d",
+            "value": None,
+        },
+        {
+            "timestamp": "2019-08-01T15:45:37.000000000Z",
+            "metric": "e",
+            "value": None,
+        },
+        {
+            "timestamp": "2019-08-01T15:45:46.000000000Z",
+            "metric": "a",
+            "value": 1.9,
+        },
+        {
+            "timestamp": "2019-08-01T15:45:56.000000000Z",
+            "metric": "a",
+            "value": 1.5,
+        },
+        {
+            "timestamp": "2019-08-01T15:45:57.000000000Z",
+            "metric": "e",
+            "value": "text",
+        },
+    ]
+    assert "Data-Attributes" not in kwargs_2["headers"]
+
+    _, _, kwargs_3 = mocked_api.mock_calls[2]
+    assert kwargs_3["params"] == [
+        ("id", "sink_id_3"),
+        ("filter_key_3", "filter_value_3"),
+    ]
+    assert kwargs_3["json"] == []
+
+
+@pytest.mark.asyncio
+async def test_send_multitsframe_no_df(mocked_url, mocked_api) -> None:
+    no_mts = pd.Series([1.0], index=pd.to_datetime(["2019-08-01T15:45:36Z"]))
+    with pytest.raises(AdapterOutputDataError, match="Did not receive Pandas DataFrame"):
         await send_data(
             {
-                "outp_1": FilteredSink(
-                    ref_id="sink_id_1",
+                "outp": FilteredSink(
+                    ref_id="sink_id",
                     type="multitsframe",
-                    filters={"filter_key_1": "filter_value_1"},
-                ),
-                "outp_2": FilteredSink(
-                    ref_id="sink_id_2",
-                    type=ExternalType.MULTITSFRAME,
-                    filters={"filter_key_2": "filter_value_2"},
-                ),
-                "outp_3": FilteredSink(
-                    ref_id="sink_id_3",
-                    type=ExternalType.MULTITSFRAME,
-                    filters={"filter_key_3": "filter_value_3"},
-                ),
+                    filters={},
+                )
             },
-            {"outp_1": mtsf_1, "outp_2": mtsf_2, "outp_3": pd.DataFrame([])},
+            {"outp": no_mts},
             adapter_key="test_end_to_end_send_only_multitsframe_data",
         )
-        assert post_mock.called  # we got through to actually posting!
-        _, _, kwargs_1 = post_mock.mock_calls[0]
-        assert kwargs_1["params"] == [
-            ("id", "sink_id_1"),
-            ("filter_key_1", "filter_value_1"),
-        ]
-        assert kwargs_1["json"] == [
-            {
-                "timestamp": "2019-08-01T15:45:36.000000000Z",
-                "metric": "a",
-                "value": 1.0,
-            },
-            {
-                "timestamp": "2019-08-01T15:45:37.000000000Z",
-                "metric": "b",
-                "value": 1.2,
-            },
-            {
-                "timestamp": "2019-08-01T15:45:37.000000000Z",
-                "metric": "c",
-                "value": 0.5,
-            },
-            {
-                "timestamp": "2019-08-01T15:45:46.000000000Z",
-                "metric": "a",
-                "value": 1.9,
-            },
-            {
-                "timestamp": "2019-08-01T15:45:46.000000000Z",
-                "metric": "b",
-                "value": 1.3,
-            },
-            {
-                "timestamp": "2019-08-01T15:45:47.000000000Z",
-                "metric": "c",
-                "value": 0.2,
-            },
-            {
-                "timestamp": "2019-08-01T15:45:56.000000000Z",
-                "metric": "a",
-                "value": 1.5,
-            },
-            {
-                "timestamp": "2019-08-01T15:45:57.000000000Z",
-                "metric": "b",
-                "value": 1.7,
-            },
-            {
-                "timestamp": "2019-08-01T15:45:58.000000000Z",
-                "metric": "c",
-                "value": 0.1,
-            },
-        ]
-        assert "Data-Attributes" in kwargs_1["headers"]
-        received_attrs = decode_attributes(kwargs_1["headers"]["Data-Attributes"])
-        assert received_attrs["from"] == "2019-08-01T15:45:30.000Z"
-        assert received_attrs["to"] == "2019-08-01T15:46:00.000Z"
-
-        _, _, kwargs_2 = post_mock.mock_calls[1]
-        assert kwargs_2["params"] == [
-            ("id", "sink_id_2"),
-            ("filter_key_2", "filter_value_2"),
-        ]
-        assert kwargs_2["json"] == [
-            {
-                "timestamp": "2019-08-01T15:45:36.000000000Z",
-                "metric": "a",
-                "value": 1.0,
-            },
-            {
-                "timestamp": "2019-08-01T15:45:37.000000000Z",
-                "metric": "d",
-                "value": None,
-            },
-            {
-                "timestamp": "2019-08-01T15:45:37.000000000Z",
-                "metric": "e",
-                "value": None,
-            },
-            {
-                "timestamp": "2019-08-01T15:45:46.000000000Z",
-                "metric": "a",
-                "value": 1.9,
-            },
-            {
-                "timestamp": "2019-08-01T15:45:56.000000000Z",
-                "metric": "a",
-                "value": 1.5,
-            },
-            {
-                "timestamp": "2019-08-01T15:45:57.000000000Z",
-                "metric": "e",
-                "value": "text",
-            },
-        ]
-        assert "Data-Attributes" not in kwargs_2["headers"]
-
-        _, _, kwargs_3 = post_mock.mock_calls[2]
-        assert kwargs_3["params"] == [
-            ("id", "sink_id_3"),
-            ("filter_key_3", "filter_value_3"),
-        ]
-        assert kwargs_3["json"] == []
-
-        no_mtsf = pd.Series([1.0], index=pd.to_datetime(["2019-08-01T15:45:36Z"]))
-        with pytest.raises(AdapterOutputDataError, match="Did not receive Pandas DataFrame"):
-            await send_data(
-                {
-                    "outp_4": FilteredSink(
-                        ref_id="sink_id_4",
-                        type="multitsframe",
-                        filters={},
-                    )
-                },
-                {"outp_4": no_mtsf},
-                adapter_key="test_end_to_end_send_only_multitsframe_data",
-            )
-
-        mtsf_5 = pd.DataFrame(
-            {
-                "wrong_column_name": ["a"],
-                "timestamp": [pd.Timestamp("2019-08-01T15:45:36Z")],
-                "value": [1.0],
-            }
-        )
-        with pytest.raises(AdapterOutputDataError, match=r"column names.* don't match"):
-            await send_data(
-                {"outp_5": FilteredSink(ref_id="sink_id_5", type="multitsframe")},
-                {"outp_5": mtsf_5},
-                adapter_key="test_end_to_end_send_only_multitsframe_data",
-            )
-
-        mtsf_6 = pd.DataFrame(
-            {
-                "metric": [np.nan],
-                "timestamp": [pd.Timestamp("2019-08-01T15:45:36Z")],
-                "value": [1.0],
-            }
-        )
-        with pytest.raises(AdapterOutputDataError, match=r"null values in.*metric"):
-            await send_data(
-                {"outp_6": FilteredSink(ref_id="sink_id_6", type="multitsframe")},
-                {"outp_6": mtsf_6},
-                adapter_key="test_end_to_end_send_only_multitsframe_data",
-            )
-
-        mtsf_7 = pd.DataFrame({"metric": ["a"], "timestamp": [pd.NaT], "value": [1.0]})
-        with pytest.raises(AdapterOutputDataError, match=r"null values in.*timestamp"):
-            await send_data(
-                {"outp_7": FilteredSink(ref_id="sink_id_7", type="multitsframe")},
-                {"outp_7": mtsf_7},
-                adapter_key="test_end_to_end_send_only_multitsframe_data",
-            )
-
-        mtsf_8 = pd.DataFrame({"metric": ["a"], "timestamp": ["not a timestamp"], "value": [1.0]})
-        with pytest.raises(AdapterOutputDataError, match="does not have DatetimeTZDtype dtype"):
-            await send_data(
-                {"outp_8": FilteredSink(ref_id="sink_id_8", type="multitsframe")},
-                {"outp_8": mtsf_8},
-                adapter_key="test_end_to_end_send_only_multitsframe_data",
-            )
-
-        mtsf_9 = pd.DataFrame(
-            {
-                "metric": ["a"],
-                "timestamp": [pd.Timestamp("2019-08-01T15:45:36+01:00")],
-                "value": [1.0],
-            }
-        )
-        with pytest.raises(AdapterOutputDataError, match="does not have UTC timezone"):
-            await send_data(
-                {"outp_9": FilteredSink(ref_id="sink_id_9", type="multitsframe")},
-                {"outp_9": mtsf_9},
-                adapter_key="test_end_to_end_send_only_multitsframe_data",
-            )
 
 
 @pytest.mark.asyncio
-async def test_send_multitsframe_extra_columns() -> None:
-    post_mock = mock.AsyncMock(return_value=mock.Mock(status_code=200))
-
-    with (
-        mock.patch(  # noqa: SIM117
-            "hetdesrun.adapters.generic_rest.send_framelike.get_generic_rest_adapter_base_url",
-            return_value="https://hetida.de",
-        ),
-        mock.patch(
-            "hetdesrun.adapters.generic_rest.send_multitsframe.AsyncClient.post",
-            new=post_mock,
-        ),
-    ):
-        mts = pd.DataFrame(
-            {
-                "metric": ["a"],
-                "timestamp": [pd.Timestamp("2019-08-01T15:45:36Z")],
-                "value": [1.0],
-                "min": [0.0],
-            }
-        )
-
+async def test_send_multitsframe_wrong_colnames(mocked_url, mocked_api) -> None:
+    mts = pd.DataFrame(
+        {
+            "any_column_name": ["a"],
+            "timestamps": [pd.Timestamp("2019-08-01T15:45:36Z")],
+            "value": [1.0],
+        }
+    )
+    with pytest.raises(
+        AdapterOutputDataError, match=r"column names.* don't contain"
+    ):  # The column names { {*df.columns} } don't contain
         await send_data(
-            {"outp": FilteredSink(ref_id="sink_id_8", type="multitsframe")},
+            {"outp": FilteredSink(ref_id="sink_id", type="multitsframe")},
             {"outp": mts},
             adapter_key="test_end_to_end_send_only_multitsframe_data",
         )
 
-        assert post_mock.called  # we got through to actually posting!
+
+@pytest.mark.asyncio
+async def test_send_multitsframe_too_few_columns(mocked_url, mocked_api) -> None:
+    mts = pd.DataFrame(
+        {
+            "timestamp": [pd.Timestamp("2019-08-01T15:45:36Z")],
+            "value": [1.0],
+        }
+    )
+    with pytest.raises(
+        AdapterOutputDataError, match=r"requires at least 3 columns"
+    ):  # The column names { {*df.columns} } don't contain
+        await send_data(
+            {"outp": FilteredSink(ref_id="sink_id", type="multitsframe")},
+            {"outp": mts},
+            adapter_key="test_end_to_end_send_only_multitsframe_data",
+        )
+
+
+@pytest.mark.asyncio
+async def test_send_multitsframe_nan_in_metric(mocked_url, mocked_api) -> None:
+    mts = pd.DataFrame(
+        {
+            "metric": [np.nan],
+            "timestamp": [pd.Timestamp("2019-08-01T15:45:36Z")],
+            "value": [1.0],
+        }
+    )
+    with pytest.raises(AdapterOutputDataError, match=r"null values in.*metric"):
+        await send_data(
+            {"outp": FilteredSink(ref_id="sink_id", type="multitsframe")},
+            {"outp": mts},
+            adapter_key="test_end_to_end_send_only_multitsframe_data",
+        )
+
+
+@pytest.mark.asyncio
+async def test_send_multitsframe_nan_in_timestamp(mocked_url, mocked_api) -> None:
+    mts = pd.DataFrame({"metric": ["a"], "timestamp": [pd.NaT], "value": [1.0]})
+    with pytest.raises(AdapterOutputDataError, match=r"null values in.*timestamp"):
+        await send_data(
+            {"outp": FilteredSink(ref_id="sink_id", type="multitsframe")},
+            {"outp": mts},
+            adapter_key="test_end_to_end_send_only_multitsframe_data",
+        )
+
+
+@pytest.mark.asyncio
+async def test_send_multitsframe_no_timestampformat(mocked_url, mocked_api) -> None:
+    mts = pd.DataFrame({"metric": ["a"], "timestamp": ["not a timestamp"], "value": [1.0]})
+    with pytest.raises(AdapterOutputDataError, match="does not have DatetimeTZDtype dtype"):
+        await send_data(
+            {"outp": FilteredSink(ref_id="sink_id", type="multitsframe")},
+            {"outp": mts},
+            adapter_key="test_end_to_end_send_only_multitsframe_data",
+        )
+
+
+@pytest.mark.asyncio
+async def test_send_multitsframe_no_utc(mocked_url, mocked_api) -> None:
+    mts = pd.DataFrame(
+        {
+            "metric": ["a"],
+            "timestamp": [pd.Timestamp("2019-08-01T15:45:36+01:00")],
+            "value": [1.0],
+        }
+    )
+    with pytest.raises(AdapterOutputDataError, match="does not have UTC timezone"):
+        await send_data(
+            {"outp": FilteredSink(ref_id="sink_id", type="multitsframe")},
+            {"outp": mts},
+            adapter_key="test_end_to_end_send_only_multitsframe_data",
+        )
+
+
+@pytest.mark.asyncio
+async def test_send_multitsframe_extra_columns(mocked_url, mocked_api) -> None:
+    mts = pd.DataFrame(
+        {
+            "metric": ["a"],
+            "timestamp": [pd.Timestamp("2019-08-01T15:45:36Z")],
+            "value": [1.0],
+            "min": [0.0],
+        }
+    )
+
+    await send_data(
+        {"outp": FilteredSink(ref_id="sink_id", type="multitsframe")},
+        {"outp": mts},
+        adapter_key="test_end_to_end_send_only_multitsframe_data",
+    )
+
+    assert mocked_api.called  # we got through to actually posting!

--- a/runtime/tests/generic_rest_adapter/test_send_multitsframe.py
+++ b/runtime/tests/generic_rest_adapter/test_send_multitsframe.py
@@ -257,6 +257,7 @@ async def test_end_to_end_send_only_multitsframe_data() -> None:
                 adapter_key="test_end_to_end_send_only_multitsframe_data",
             )
 
+
 @pytest.mark.asyncio
 async def test_send_multitsframe_extra_columns() -> None:
     post_mock = mock.AsyncMock(return_value=mock.Mock(status_code=200))
@@ -271,19 +272,19 @@ async def test_send_multitsframe_extra_columns() -> None:
             new=post_mock,
         ),
     ):
-
         mts = pd.DataFrame(
             {
                 "metric": ["a"],
                 "timestamp": [pd.Timestamp("2019-08-01T15:45:36Z")],
                 "value": [1.0],
-                "min": [0.0]
-            })
+                "min": [0.0],
+            }
+        )
 
         await send_data(
             {"outp": FilteredSink(ref_id="sink_id_8", type="multitsframe")},
             {"outp": mts},
-            adapter_key="test_end_to_end_send_only_multitsframe_data"
+            adapter_key="test_end_to_end_send_only_multitsframe_data",
         )
 
         assert post_mock.called  # we got through to actually posting!


### PR DESCRIPTION
- enable additional column names in multitsframes in generic rest adapter
- add unittest to check
- enable other colum name than "value" in mts in generic rest adapter
- refactor tests (smaller scopes) 
- start documentation of data_types in hd