### PR TITLE
replace hyphens by underscores in hdctl _slugify

### DIFF
--- a/hdctl
+++ b/hdctl
@@ -1736,6 +1736,7 @@ _slugify() {
               gsub(/^[ \t\r\n]+/, "");
               gsub(/[ \t\r\n]+$/, "");
               gsub(/[ ]+/,"_");
+              gsub(/-/,"_");
               print tolower($0);
         }'
 }


### PR DESCRIPTION
Having hyphens in the filenames makes importing and in particular patching code parts in tests more complicated.

Thus we replace the hyphens (which in particular are part of the uuid strings) by underscores in hdctl _slugify, and therefore "hdctl sync pull" produces filenames with underscores instead of hyphens. 
My understanding is that the filenames are not used e.g. when doing a "hdctl sync push", so it is just a single line which is changed. (Tests pass.)