### PR TITLE
HDOS-763 maintenance endpoint extension

### DIFF
--- a/hdctl
+++ b/hdctl
@@ -1487,7 +1487,24 @@ usage() {
     echo "      $0 purge"
     echo "      $0 deploy_base_trafos"
     echo "      $0 autoimport"
-    echo
+    echo ""
+    echo "    Execution examples:"
+    echo ""
+    echo "        ./hdctl delete_drafts -i hd-docker-compose -m test123"
+    echo ""
+    echo "    This applies the delete_drafts command and defining instance file"
+    echo "    and maintenance secret."
+    echo ""
+    echo ""
+    echo "        ./hdctl delete_unused_deprecated -i hd-docker-compose -m test123"
+    echo "             -cutoff 2026-05-05 10:00:00Z"
+    echo "             -exclude uuid1 -exclude uud2"
+    echo ""
+    echo "    This applies the delete_unused_deprecated command defining instance file"
+    echo "    and maintenance secret and using the arguments cutoff_date and exclude."
+    echo "    For the documentation of the effect of these parameter please have a look"
+    echo "    at openapi.yaml/Swagger UI of the backend."
+    echo ""
 }
 
 help() {
@@ -1687,6 +1704,8 @@ delete_drafts() {
 #     **Warning**: This irrevocably deletes transformation revisions. We recommend to backup, e.g.
 #     exporting / getting all transformation revisions before using this action!
 delete_unused_deprecated() {
+
+    # Global set up
     _setup "${@}"
     _ensure_maintenance_secret
     ensure_access_token
@@ -1695,12 +1714,25 @@ delete_unused_deprecated() {
     if [[ $VERIFY_BACKEND_API_URL = false ]]; then
         curl_args+=("--insecure")
     fi
-    curl "${curl_args[@]}" -X POST \
+
+    # function set up
+    _parse_delete_unused_deprecated_args "${@}"
+    _build_body_delete_unused_deprecated_args
+
+    # excecute CURL-command
+    local cmd=(
+        curl \
+        "${curl_args[@]}" \
+        -X POST \
         -H "Authorization: Bearer $ACCESS_TOKEN" \
         -H "Content-Type: application/json" \
-        -d '{"maintenance_secret":"'"$MAINTENANCE_SECRET"'"}' \
+        -d "$BODY" \
         "$HD_BACKEND_API_URL/maintenance/delete_unused_deprecated$QUERY_URL_APPEND" \
         "${REMAINING_ARGS[@]}"
+    )
+
+    "${cmd[@]}" # printf '%q ' "${cmd[@]}" for dry-run
+
 }
 
 # Purge and reinstall base components/workflows
@@ -2383,6 +2415,57 @@ _setup() {
     _validate_global_parameters
 }
 
+_parse_delete_unused_deprecated_args() {
+
+    CUTOFF_DATE=""
+    EXCLUDE_UUIDS=()
+
+    set -- "${REMAINING_ARGS[@]}"
+
+    REMAINING_ARGS=()
+    while [[ "$#" -gt 0 ]];
+        do case "$1" in
+            -exclude)
+                EXCLUDE_UUIDS+=("$2")
+                shift 2
+                ;;
+            -cutoff)
+                CUTOFF_DATE="$2"
+                shift 2
+                ;;
+            *)
+            REMAINING_ARGS+=("$1")
+            shift
+        ;;
+        esac
+    done
+    REMAINING_ARGS=("${REMAINING_ARGS[@]}" "${@}")
+}
+
+_build_body_delete_unused_deprecated_args() {
+
+    BODY='{
+        "maintenance_payload": {
+            "maintenance_secret": "'"$MAINTENANCE_SECRET"'"
+    }'
+
+    if [[ -n "$CUTOFF_DATE" ]]; then
+        BODY+=',
+    "cutoff_date": "'"$CUTOFF_DATE"'"'
+    fi
+
+    if ((${#EXCLUDE_UUIDS[@]})); then
+        BODY+=',
+        "exclude": ['
+        for i in "${!EXCLUDE_UUIDS[@]}"; do
+            [[ $i -gt 0 ]] && BODY+=","
+            BODY+="\"${EXCLUDE_UUIDS[$i]}\""
+        done
+        BODY+=']'
+    fi
+
+    BODY+="}"
+}
 ###############################################################################
 #                                                                             #
 #                             Subcommand Execution                            #

--- a/hdctl
+++ b/hdctl
@@ -1672,8 +1672,20 @@ delete_drafts() {
 #     "Unused" deprecated transformation revisions are those that are either not used in any workflow
 #     or only in workflows that themselves are deprecated (and hence will be deleted as well).
 
-#     This handles nesting, i.e. a deprecated trafo rev will not be deleted if it is used indirectly
-#     across multiple nesting levels in a workflow which is not deprecated.
+#     This handles nesting, i.e. a deprecated transformation revision will not be deleted if it is used
+#     indirectly across multiple nesting levels in a workflow which is not deprecated.
+
+#     To avoid deleting certain transformation, use the exclude parameter by listing the uuids
+#     of these transformations, e.g., &exclude=[uuid1,uuid2,...]. By default all unused deprecated
+#     transformations are deleted.
+
+#     To avoid that recently deprecated transformations are deleted, use the parameter cutoff_date
+#     that enables deleting only transformations that have been disabled before the given date.
+#     the parameter must be a n iso-formatted date in UTC, e.g., ?cutoff_date="2026-01-01 00:00:00Z".
+#     By default all unused deprecated transformations are deleted.
+
+#     **Warning**: This irrevocably deletes transformation revisions. We recommend to backup, e.g.
+#     exporting / getting all transformation revisions before using this action!
 delete_unused_deprecated() {
     _setup "${@}"
     _ensure_maintenance_secret

--- a/runtime/hetdesrun/backend/service/maintenance_router.py
+++ b/runtime/hetdesrun/backend/service/maintenance_router.py
@@ -1,10 +1,11 @@
 import logging
 import secrets
 from collections.abc import Callable
-from typing import Any
+from typing import Annotated, Any
+from uuid import UUID
 
-from fastapi import HTTPException, Query, Response, status
-from pydantic import BaseModel, Field, SecretStr
+from fastapi import Body, HTTPException, Query, Response, status
+from pydantic import AwareDatetime, BaseModel, Field, SecretStr
 
 from hetdesrun.exportimport.importing import import_importables, import_transformations_from_dir
 from hetdesrun.exportimport.purge import (
@@ -158,29 +159,34 @@ async def maintenance_delete_drafts(
 async def maintenance_delete_unused_deprecated(
     maintenance_payload: MaintenancePayload,
     response: Response,
-    exclude: list[str] | None = None,
-    cutoff_date: str | None = None,
+    exclude: Annotated[list[UUID] | None, Body()] = None,
+    cutoff_date: Annotated[AwareDatetime | None, Body()] = None,
 ) -> MaintenanceActionResult:
     """Delete all unused deprecated transformation revisions
 
-    "Unused" deprecated transformation revisions are those that are either not used in any workflow
-    or only in workflows that themselves are deprecated (and hence will be deleted as well).
+    'Unused' deprecated transformation revisions are those that are either not used in any workflow
+    or are used only in workflows that are themselves deprecated (and therefore will be deleted as
+    well).
 
-    This handles nesting, i.e. a deprecated transformation revision will not be deleted if it is
+    This handles nesting, i.e., a deprecated transformation revision will not be deleted if it is
     used indirectly across multiple nesting levels in a workflow which is not deprecated.
 
-    To avoid deleting certain transformation, use the exclude parameter by listing the uuids
-    of these transformations, e.g., &exclude=[uuid1,uuid2,...]. By default all unused deprecated
-    transformations are deleted.
+    To prevent certain transformations from being deleted, use the exclude parameter and provide
+    a list of transformation UUIDs, for example: &exclude=[uuid1,uuid2,...]. By default, all unused
+    deprecated transformations are deleted.
 
-    To avoid that recently deprecated transformations are deleted, use the parameter cutoff_date
-    that enables deleting only transformations that have been disabled before the given date.
-    the parameter must be a n iso-formatted date in UTC, e.g., ?cutoff_date="2026-01-01 00:00:00Z".
-    By default all unused deprecated transformations are deleted.
+    To prevent recently deprecated transformations from being deleted, use the cutoff_date
+    parameter. This parameter restricts deletion to transformations that were disabled before
+    the specified date. The parameter must be an ISO 8601-formatted UTC timestamp, for example:
+    &cutoff_date=2026-01-01T00:00:00Z. By default, all unused deprecated transformations are
+    deleted.
 
-    **Warning**: This irrevocably deletes transformation revisions. We recommend to backup, e.g.
-    exporting / getting all transformation revisions before using this action!
+    **Warning**: This action permanently deletes transformation revisions. We recommend creating
+    a backup (for example, by exporting all transformation revisions) before using this action.
     """
+
+    logger.debug(f"list exclude parameter in endpoint: {exclude}")
+    logger.debug(f"cutoff_date: {cutoff_date}")
 
     return handle_maintenance_operation_request(
         "delete_unused_deprecated",

--- a/runtime/hetdesrun/backend/service/maintenance_router.py
+++ b/runtime/hetdesrun/backend/service/maintenance_router.py
@@ -171,22 +171,19 @@ async def maintenance_delete_unused_deprecated(
     This handles nesting, i.e., a deprecated transformation revision will not be deleted if it is
     used indirectly across multiple nesting levels in a workflow which is not deprecated.
 
-    To prevent certain transformations from being deleted, use the exclude parameter and provide
-    a list of transformation UUIDs, for example: &exclude=[uuid1,uuid2,...]. By default, all unused
-    deprecated transformations are deleted.
+    To prevent certain transformations from being deleted, use the exclude body-parameter and
+    provide a list of transformation UUIDs, for example: "exclude":["uuid1","uuid2",...].
+    By default, all unused deprecated transformations are deleted.
 
     To prevent recently deprecated transformations from being deleted, use the cutoff_date
-    parameter. This parameter restricts deletion to transformations that were disabled before
+    body-parameter. This parameter restricts deletion to transformations that were disabled after
     the specified date. The parameter must be an ISO 8601-formatted UTC timestamp, for example:
-    &cutoff_date=2026-01-01T00:00:00Z. By default, all unused deprecated transformations are
+    "cutoff_date":"2026-01-01T00:00:00Z". By default, all unused deprecated transformations are
     deleted.
 
     **Warning**: This action permanently deletes transformation revisions. We recommend creating
     a backup (for example, by exporting all transformation revisions) before using this action.
     """
-
-    logger.debug(f"list exclude parameter in endpoint: {exclude}")
-    logger.debug(f"cutoff_date: {cutoff_date}")
 
     return handle_maintenance_operation_request(
         "delete_unused_deprecated",

--- a/runtime/hetdesrun/backend/service/maintenance_router.py
+++ b/runtime/hetdesrun/backend/service/maintenance_router.py
@@ -48,7 +48,7 @@ def handle_maintenance_operation_request(
     secret_str: SecretStr,
     func: Callable[..., None],
     response: Response,
-    **kwargs: Any
+    **kwargs: Any,
 ) -> MaintenanceActionResult:
     """Handle maintenance request
 
@@ -58,9 +58,7 @@ def handle_maintenance_operation_request(
 
     configured_maintenance_secret = get_config().maintenance_secret
 
-    assert configured_maintenance_secret is not None  # for mypy # noqa: S101
-
-    if not secrets.compare_digest(
+    if configured_maintenance_secret is None or not secrets.compare_digest(
         secret_str.get_secret_value(),
         configured_maintenance_secret.get_secret_value(),
     ):
@@ -70,7 +68,7 @@ def handle_maintenance_operation_request(
             detail={"authorization_error": "maintenance secret check failed"},
         )
     try:
-        func(directly_in_db=True, **kwargs)
+        func(**kwargs)
     except Exception as exc:  # noqa: BLE001
         msg = f"Exception during maintenance operation {maintenance_operation_name}:\n" + str(exc)
         logger.error(msg)
@@ -99,6 +97,7 @@ async def maintenance_reset_test_wiring_to_release_wiring(
         maintenance_payload.maintenance_secret,
         reset_test_wiring_to_release_wiring,
         response=response,
+        directly_in_db=True,
     )
 
 
@@ -125,6 +124,7 @@ async def maintenance_deprecate_all_but_latest_per_group(
         maintenance_payload.maintenance_secret,
         deprecate_all_but_latest_per_group,
         response=response,
+        directly_in_db=True,
     )
 
 
@@ -146,6 +146,7 @@ async def maintenance_delete_drafts(
         maintenance_payload.maintenance_secret,
         delete_drafts,
         response=response,
+        directly_in_db=True,
     )
 
 
@@ -155,26 +156,40 @@ async def maintenance_delete_drafts(
     summary="delete all unused deprecated transformation revisions",
 )
 async def maintenance_delete_unused_deprecated(
-    maintenance_payload: MaintenancePayload, response: Response, exclude: list[str] = None, since: str = None,
+    maintenance_payload: MaintenancePayload,
+    response: Response,
+    exclude: list[str] | None = None,
+    cutoff_date: str | None = None,
 ) -> MaintenanceActionResult:
     """Delete all unused deprecated transformation revisions
 
     "Unused" deprecated transformation revisions are those that are either not used in any workflow
     or only in workflows that themselves are deprecated (and hence will be deleted as well).
 
-    This handles nesting, i.e. a deprecated trafo rev will not be deleted if it is used indirectly
-    across multiple nesting levels in a workflow which is not deprecated.
+    This handles nesting, i.e. a deprecated transformation revision will not be deleted if it is
+    used indirectly across multiple nesting levels in a workflow which is not deprecated.
+
+    To avoid deleting certain transformation, use the exclude parameter by listing the uuids
+    of these transformations, e.g., &exclude=[uuid1,uuid2,...]. By default all unused deprecated
+    transformations are deleted.
+
+    To avoid that recently deprecated transformations are deleted, use the parameter cutoff_date
+    that enables deleting only transformations that have been disabled before the given date.
+    the parameter must be a n iso-formatted date in UTC, e.g., ?cutoff_date="2026-01-01 00:00:00Z".
+    By default all unused deprecated transformations are deleted.
 
     **Warning**: This irrevocably deletes transformation revisions. We recommend to backup, e.g.
     exporting / getting all transformation revisions before using this action!
     """
+
     return handle_maintenance_operation_request(
         "delete_unused_deprecated",
         maintenance_payload.maintenance_secret,
         delete_unused_deprecated,
         response=response,
+        directly_in_db=True,
         exclude=exclude,
-        since=since
+        cutoff_date=cutoff_date,
     )
 
 
@@ -200,6 +215,7 @@ async def maintenance_purge(
         maintenance_payload.maintenance_secret,
         delete_all_and_refill,
         response=response,
+        directly_in_db=True,
     )
 
 
@@ -261,10 +277,11 @@ async def deploy_base_trafos(
         maintenance_payload.maintenance_secret,
         handle_base_deployment,
         response=response,
+        directly_in_db=True,
     )
 
 
-def autoimport(directly_in_db: bool = True) -> None:  # noqa: ARG001
+def autoimport() -> None:
     autoimport_dir = get_config().autoimport_directory
     logger.info("Trying autoimport from %s", autoimport_dir)
 
@@ -273,7 +290,7 @@ def autoimport(directly_in_db: bool = True) -> None:  # noqa: ARG001
 
 
 @maintenance_router.post(
-    "/trigger_automimport",
+    "/trigger_autoimport",
     response_model=MaintenanceActionResult,
     summary="Trigger autoimport",
 )
@@ -288,7 +305,7 @@ async def trigger_autoimport(
     configured via the HD_BACKEND_AUTOIMPORT_DIRECTORY environment variable.
     """
     return handle_maintenance_operation_request(
-        "trigger_automimport",
+        "trigger_autoimport",
         maintenance_payload.maintenance_secret,
         autoimport,
         response=response,

--- a/runtime/hetdesrun/backend/service/maintenance_router.py
+++ b/runtime/hetdesrun/backend/service/maintenance_router.py
@@ -1,6 +1,7 @@
 import logging
 import secrets
 from collections.abc import Callable
+from typing import Any
 
 from fastapi import HTTPException, Query, Response, status
 from pydantic import BaseModel, Field, SecretStr
@@ -47,6 +48,7 @@ def handle_maintenance_operation_request(
     secret_str: SecretStr,
     func: Callable[..., None],
     response: Response,
+    **kwargs: Any
 ) -> MaintenanceActionResult:
     """Handle maintenance request
 
@@ -68,7 +70,7 @@ def handle_maintenance_operation_request(
             detail={"authorization_error": "maintenance secret check failed"},
         )
     try:
-        func(directly_in_db=True)
+        func(directly_in_db=True, **kwargs)
     except Exception as exc:  # noqa: BLE001
         msg = f"Exception during maintenance operation {maintenance_operation_name}:\n" + str(exc)
         logger.error(msg)
@@ -153,7 +155,7 @@ async def maintenance_delete_drafts(
     summary="delete all unused deprecated transformation revisions",
 )
 async def maintenance_delete_unused_deprecated(
-    maintenance_payload: MaintenancePayload, response: Response
+    maintenance_payload: MaintenancePayload, response: Response, exclude: list[str] = None, since: str = None,
 ) -> MaintenanceActionResult:
     """Delete all unused deprecated transformation revisions
 
@@ -171,6 +173,8 @@ async def maintenance_delete_unused_deprecated(
         maintenance_payload.maintenance_secret,
         delete_unused_deprecated,
         response=response,
+        exclude=exclude,
+        since=since
     )
 
 

--- a/runtime/hetdesrun/exportimport/purge.py
+++ b/runtime/hetdesrun/exportimport/purge.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime
+from datetime import datetime, timezone, timedelta
 from uuid import UUID
 
 from hetdesrun.exportimport.importing import import_transformations_from_dir
@@ -78,7 +78,7 @@ def delete_unused_deprecated(
     cutoff_date_dt = (
         datetime.fromisoformat(cutoff_date)
         if cutoff_date
-        else datetime.fromisoformat("1970-01-01 00:00:00Z")
+        else datetime.now(timezone.utc) + timedelta(days=1)
     )
 
     tr_list_reduced = []
@@ -86,10 +86,12 @@ def delete_unused_deprecated(
     for trafo in tr_list:
         # Skip explicitly excluded entries
         if trafo.id in excluded_ids:
+            logger.debug(f"Deleting disabled ... Skipping {trafo.name}")
             continue
 
         # Skip entries newer than the cutoff date
         if trafo.disabled_timestamp and trafo.disabled_timestamp > cutoff_date_dt:
+            logger.debug(f"Deleting disabled ... Skipping {trafo.name}")
             continue
 
         tr_list_reduced.append(trafo)

--- a/runtime/hetdesrun/exportimport/purge.py
+++ b/runtime/hetdesrun/exportimport/purge.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime
 from uuid import UUID
 
 from hetdesrun.exportimport.importing import import_transformations_from_dir
@@ -64,18 +65,36 @@ def delete_drafts(directly_in_db: bool = False) -> None:
     delete_transformation_revisions(tr_list, directly_in_db=directly_in_db)
 
 
-def delete_unused_deprecated(directly_in_db: bool = False, exclude: list[str] = None, since: str = None) -> None:
+def delete_unused_deprecated(
+    directly_in_db: bool = False, exclude: list[str] | None = None, cutoff_date: str | None = None
+) -> None:
+
     tr_list = get_transformation_revisions(
         params=FilterParams(state=State.DISABLED, include_dependencies=False, unused=True),
         directly_from_db=directly_in_db,
     )
 
-    # here i have to filter
-    logger.info(f"exclude: {exclude}")
-    logger.info(f"since: {since}")
-    logger.info(f"tr_list: {tr_list}")
+    excluded_ids = [UUID(entry) for entry in exclude] if exclude else []
+    cutoff_date_dt = (
+        datetime.fromisoformat(cutoff_date)
+        if cutoff_date
+        else datetime.fromisoformat("1970-01-01 00:00:00Z")
+    )
 
-    delete_transformation_revisions(tr_list, directly_in_db=directly_in_db)
+    tr_list_reduced = []
+
+    for trafo in tr_list:
+        # Skip explicitly excluded entries
+        if trafo.id in excluded_ids:
+            continue
+
+        # Skip entries newer than the cutoff date
+        if trafo.disabled_timestamp and trafo.disabled_timestamp > cutoff_date_dt:
+            continue
+
+        tr_list_reduced.append(trafo)
+
+    delete_transformation_revisions(tr_list_reduced, directly_in_db=directly_in_db)
 
 
 def delete_all_and_refill(directly_in_db: bool = False) -> None:

--- a/runtime/hetdesrun/exportimport/purge.py
+++ b/runtime/hetdesrun/exportimport/purge.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta, timezone
 from uuid import UUID
 
 from hetdesrun.exportimport.importing import import_transformations_from_dir
@@ -86,12 +86,12 @@ def delete_unused_deprecated(
     for trafo in tr_list:
         # Skip explicitly excluded entries
         if trafo.id in excluded_ids:
-            logger.debug(f"Deleting disabled ... Skipping {trafo.name}")
+            logger.debug("Deleting disabled ... Skipping %s, trafo.name")
             continue
 
         # Skip entries newer than the cutoff date
         if trafo.disabled_timestamp and trafo.disabled_timestamp > cutoff_date_dt:
-            logger.debug(f"Deleting disabled ... Skipping {trafo.name}")
+            logger.debug("Deleting disabled ... Skipping %s", trafo.name)
             continue
 
         tr_list_reduced.append(trafo)

--- a/runtime/hetdesrun/exportimport/purge.py
+++ b/runtime/hetdesrun/exportimport/purge.py
@@ -64,11 +64,16 @@ def delete_drafts(directly_in_db: bool = False) -> None:
     delete_transformation_revisions(tr_list, directly_in_db=directly_in_db)
 
 
-def delete_unused_deprecated(directly_in_db: bool = False) -> None:
+def delete_unused_deprecated(directly_in_db: bool = False, exclude: list[str] = None, since: str = None) -> None:
     tr_list = get_transformation_revisions(
         params=FilterParams(state=State.DISABLED, include_dependencies=False, unused=True),
         directly_from_db=directly_in_db,
     )
+
+    # here i have to filter
+    logger.info(f"exclude: {exclude}")
+    logger.info(f"since: {since}")
+    logger.info(f"tr_list: {tr_list}")
 
     delete_transformation_revisions(tr_list, directly_in_db=directly_in_db)
 

--- a/runtime/hetdesrun/exportimport/purge.py
+++ b/runtime/hetdesrun/exportimport/purge.py
@@ -78,10 +78,8 @@ def delete_unused_deprecated(
         directly_from_db=directly_in_db,
     )
 
-    logger.debug(f"list exclude parameter: {exclude}")
     excluded_ids = exclude if exclude is not None else []
     cutoff_date_dt = cutoff_date if cutoff_date else datetime.now(timezone.utc) + timedelta(days=1)
-    logger.debug(f"list exclude-ids parameter: {exclude}")
     tr_list_reduced = []
 
     for trafo in tr_list:

--- a/runtime/hetdesrun/exportimport/purge.py
+++ b/runtime/hetdesrun/exportimport/purge.py
@@ -2,6 +2,8 @@ import logging
 from datetime import datetime, timedelta, timezone
 from uuid import UUID
 
+from pydantic import AwareDatetime
+
 from hetdesrun.exportimport.importing import import_transformations_from_dir
 from hetdesrun.exportimport.utils import (
     delete_transformation_revisions,
@@ -66,7 +68,9 @@ def delete_drafts(directly_in_db: bool = False) -> None:
 
 
 def delete_unused_deprecated(
-    directly_in_db: bool = False, exclude: list[str] | None = None, cutoff_date: str | None = None
+    directly_in_db: bool = False,
+    exclude: list[UUID] | None = None,
+    cutoff_date: AwareDatetime | None = None,
 ) -> None:
 
     tr_list = get_transformation_revisions(
@@ -74,24 +78,29 @@ def delete_unused_deprecated(
         directly_from_db=directly_in_db,
     )
 
-    excluded_ids = [UUID(entry) for entry in exclude] if exclude else []
-    cutoff_date_dt = (
-        datetime.fromisoformat(cutoff_date)
-        if cutoff_date
-        else datetime.now(timezone.utc) + timedelta(days=1)
-    )
-
+    logger.debug(f"list exclude parameter: {exclude}")
+    excluded_ids = exclude if exclude is not None else []
+    cutoff_date_dt = cutoff_date if cutoff_date else datetime.now(timezone.utc) + timedelta(days=1)
+    logger.debug(f"list exclude-ids parameter: {exclude}")
     tr_list_reduced = []
 
     for trafo in tr_list:
         # Skip explicitly excluded entries
         if trafo.id in excluded_ids:
-            logger.debug("Deleting disabled ... Skipping %s, trafo.name")
+            logger.debug(
+                "Transformation %s (%s) not deleted - it was explicitly excluded",
+                trafo.name,
+                trafo.version_tag,
+            )
             continue
 
         # Skip entries newer than the cutoff date
         if trafo.disabled_timestamp and trafo.disabled_timestamp > cutoff_date_dt:
-            logger.debug("Deleting disabled ... Skipping %s", trafo.name)
+            logger.debug(
+                "Transformation %s (%s) not deleted - deprecation later than specified cutoff date",
+                trafo.name,
+                trafo.version_tag,
+            )
             continue
 
         tr_list_reduced.append(trafo)

--- a/runtime/run
+++ b/runtime/run
@@ -13,6 +13,7 @@ usage() {
     echo "  - lint            :    call ruff"
     echo "  - typecheck       :    run mypy static type check"
     echo "  - format          :    run ruff format"
+    echo "  - seccheck        :    run bandit security checks"
     echo "  - check           :    run format check, tests, typechecking"
 }
 

--- a/runtime/tests/data/import_dir_components/pass_through_any_disabled_exclude.py
+++ b/runtime/tests/data/import_dir_components/pass_through_any_disabled_exclude.py
@@ -1,0 +1,50 @@
+"""Documentation for Pass Through
+
+# Pass Through
+
+## Description
+This component just passes data through.
+
+## Inputs
+* **input** (Any): The input.
+
+## Outputs
+* **output** (Any): The output.
+
+## Details
+This component just passes data through. It can be used to map one dynamic workflow input to multiple component inputs.
+"""
+
+# ***** DO NOT EDIT LINES BELOW *****
+# These lines may be overwritten if component details or inputs/outputs change.
+COMPONENT_INFO = {
+    "inputs": {
+        "input": {"data_type": "ANY"},
+    },
+    "outputs": {
+        "output": {"data_type": "ANY"},
+    },
+    "name": "Pass Through EXCLUDE",
+    "category": "Connectors",
+    "description": "Just outputs its input value",
+    "version_tag": "1.0.0",
+    "id": "1946d5f8-44a8-724c-176f-123456aaaa22",
+    "revision_group_id": "1946d5f8-44a8-724c-176f-123456aaaa23",
+    "state": "DISABLED",
+    "released_timestamp": "2022-02-09T17:33:34.387537+00:00",
+    "disabled_timestamp": "2025-06-25T17:33:34.387537+00:00",
+}
+
+from hdutils import parse_default_value  # noqa: E402, F401
+
+
+def main(*, input):
+    # entrypoint function for this component
+    # ***** DO NOT EDIT LINES ABOVE *****
+    # write your function code here.
+
+    return {"output": input}
+
+
+TEST_WIRING_FROM_PY_FILE_IMPORT = {}
+RELEASE_WIRING = {}

--- a/runtime/tests/data/import_dir_components/pass_through_any_disabled_new.py
+++ b/runtime/tests/data/import_dir_components/pass_through_any_disabled_new.py
@@ -1,0 +1,50 @@
+"""Documentation for Pass Through
+
+# Pass Through
+
+## Description
+This component just passes data through.
+
+## Inputs
+* **input** (Any): The input.
+
+## Outputs
+* **output** (Any): The output.
+
+## Details
+This component just passes data through. It can be used to map one dynamic workflow input to multiple component inputs.
+"""
+
+# ***** DO NOT EDIT LINES BELOW *****
+# These lines may be overwritten if component details or inputs/outputs change.
+COMPONENT_INFO = {
+    "inputs": {
+        "input": {"data_type": "ANY"},
+    },
+    "outputs": {
+        "output": {"data_type": "ANY"},
+    },
+    "name": "Pass Through NEW",
+    "category": "Connectors",
+    "description": "Just outputs its input value",
+    "version_tag": "1.0.0",
+    "id": "1946d5f8-44a8-724c-176f-123456aaaaa1",
+    "revision_group_id": "2946d5f8-44a8-724c-176f-123456aaaaa1",
+    "state": "DISABLED",
+    "released_timestamp": "2025-06-25T17:33:34.387537+00:00",
+    "disabled_timestamp": "2026-06-25T17:33:34.387537+00:00",
+}
+
+from hdutils import parse_default_value  # noqa: E402, F401
+
+
+def main(*, input):
+    # entrypoint function for this component
+    # ***** DO NOT EDIT LINES ABOVE *****
+    # write your function code here.
+
+    return {"output": input}
+
+
+TEST_WIRING_FROM_PY_FILE_IMPORT = {}
+RELEASE_WIRING = {}

--- a/runtime/tests/data/import_dir_components/pass_through_str.py
+++ b/runtime/tests/data/import_dir_components/pass_through_str.py
@@ -1,0 +1,49 @@
+"""Documentation for Pass Through (String)
+
+# Pass Through (String)
+
+## Description
+This component just passes data through.
+
+## Inputs
+* **input** (String): The input String.
+
+## Outputs
+* **output** (String): The output String.
+
+## Details
+This component just passes data through. It can be used to map one dynamic workflow input to multiple component inputs.
+"""
+
+# ***** DO NOT EDIT LINES BELOW *****
+# These lines may be overwritten if component details or inputs/outputs change.
+COMPONENT_INFO = {
+    "inputs": {
+        "input": {"data_type": "STRING"},
+    },
+    "outputs": {
+        "output": {"data_type": "STRING"},
+    },
+    "name": "Pass Through (String)",
+    "category": "Connectors",
+    "description": "Just outputs its input value",
+    "version_tag": "1.0.0",
+    "id": "2b1b474f-ddf5-1f4d-fec4-17ef9122112b",
+    "revision_group_id": "2b1b474f-ddf5-1f4d-fec4-17ef9122112b",
+    "state": "RELEASED",
+    "released_timestamp": "2022-02-10T03:33:33.917427+00:00",
+}
+
+from hdutils import parse_default_value  # noqa: E402, F401
+
+
+def main(*, input):
+    # entrypoint function for this component
+    # ***** DO NOT EDIT LINES ABOVE *****
+    # write your function code here.
+
+    return {"output": input}
+
+
+TEST_WIRING_FROM_PY_FILE_IMPORT = {}
+RELEASE_WIRING = {}

--- a/runtime/tests/data/import_dir_components/pass_trough_any_disabled.py
+++ b/runtime/tests/data/import_dir_components/pass_trough_any_disabled.py
@@ -1,0 +1,50 @@
+"""Documentation for Pass Through
+
+# Pass Through
+
+## Description
+This component just passes data through.
+
+## Inputs
+* **input** (Any): The input.
+
+## Outputs
+* **output** (Any): The output.
+
+## Details
+This component just passes data through. It can be used to map one dynamic workflow input to multiple component inputs.
+"""
+
+# ***** DO NOT EDIT LINES BELOW *****
+# These lines may be overwritten if component details or inputs/outputs change.
+COMPONENT_INFO = {
+    "inputs": {
+        "input": {"data_type": "ANY"},
+    },
+    "outputs": {
+        "output": {"data_type": "ANY"},
+    },
+    "name": "Pass Through OLD",
+    "category": "Connectors",
+    "description": "Just outputs its input value",
+    "version_tag": "1.0.0",
+    "id": "1946d5f8-44a8-724c-176f-123456aaaaaa",
+    "revision_group_id": "1946d5f8-44a8-724c-176f-123456aaaaaa",
+    "state": "DISABLED",
+    "released_timestamp": "2022-02-09T17:33:34.387537+00:00",
+    "disabled_timestamp": "2025-06-25T17:33:34.387537+00:00",
+}
+
+from hdutils import parse_default_value  # noqa: E402, F401
+
+
+def main(*, input):
+    # entrypoint function for this component
+    # ***** DO NOT EDIT LINES ABOVE *****
+    # write your function code here.
+
+    return {"output": input}
+
+
+TEST_WIRING_FROM_PY_FILE_IMPORT = {}
+RELEASE_WIRING = {}

--- a/runtime/tests/test_maintenance.py
+++ b/runtime/tests/test_maintenance.py
@@ -6,8 +6,11 @@ from pydantic import SecretStr
 
 from hetdesrun.backend.service.maintenance_router import (
     delete_all_and_refill,
+    delete_unused_deprecated,
     handle_maintenance_operation_request,
 )
+from hetdesrun.exportimport.importing import import_transformations_from_dir
+from hetdesrun.exportimport.utils import get_transformation_revisions
 
 
 @pytest.fixture()
@@ -22,17 +25,53 @@ def maintenance_secret_set():
 def test_maintenance_incorrect_secret(maintenance_secret_set):
     with pytest.raises(HTTPException) as exc_info:
         handle_maintenance_operation_request(
-            "purge", SecretStr("wrong_secret"), delete_all_and_refill, mock.Mock
+            "purge",
+            SecretStr("wrong_secret"),
+            delete_all_and_refill,
+            mock.Mock,
+            directly_in_db=True,
         )
     assert exc_info.value.status_code == 403
 
 
 def test_maintenance_working(maintenance_secret_set, mocked_clean_test_db_session):
     maint_response = handle_maintenance_operation_request(
-        "purge", SecretStr("testsecret"), delete_all_and_refill, mock.Mock
+        "purge",
+        SecretStr("testsecret"),
+        delete_all_and_refill,
+        mock.Mock,
+        directly_in_db=True,
     )
     assert maint_response.success
     assert maint_response.error is None
+
+
+def test_maintenance_with_kwargs(maintenance_secret_set, mocked_clean_test_db_session):
+
+    import_transformations_from_dir("./tests/data/import_dir_components", directly_into_db=True)
+
+    maint_response = handle_maintenance_operation_request(
+        maintenance_operation_name="purge",
+        secret_str=SecretStr("testsecret"),
+        func=delete_unused_deprecated,
+        response=mock.Mock,
+        directly_in_db=True,
+        exclude=["1946d5f8-44a8-724c-176f-123456aaaa22"],
+        cutoff_date="2026-01-01 00:00:00Z",
+    )
+
+    # check that function works successfully
+    assert maint_response.success
+    assert maint_response.error is None
+
+    # check if disabled components are deleted as expected
+    tr_list_after = get_transformation_revisions(
+        directly_from_db=True,
+    )
+    names = [i.name for i in tr_list_after]
+    assert "Pass Through NEW" in names
+    assert "Pass Through OLD" not in names
+    assert "Pass Through EXCLUDE" in names
 
 
 def test_maintenance_arbitrary_error(maintenance_secret_set):
@@ -41,7 +80,7 @@ def test_maintenance_arbitrary_error(maintenance_secret_set):
 
     resp_mock = mock.Mock
     maint_response = handle_maintenance_operation_request(
-        "purge", SecretStr("testsecret"), raising_func, resp_mock
+        "purge", SecretStr("testsecret"), raising_func, resp_mock, directly_in_db=True
     )
     assert not maint_response.success
     assert maint_response.error is not None

--- a/runtime/tests/test_maintenance.py
+++ b/runtime/tests/test_maintenance.py
@@ -1,4 +1,6 @@
+from datetime import datetime
 from unittest import mock
+from uuid import UUID
 
 import pytest
 from fastapi import HTTPException
@@ -56,8 +58,8 @@ def test_maintenance_with_kwargs(maintenance_secret_set, mocked_clean_test_db_se
         func=delete_unused_deprecated,
         response=mock.Mock,
         directly_in_db=True,
-        exclude=["1946d5f8-44a8-724c-176f-123456aaaa22"],
-        cutoff_date="2026-01-01 00:00:00Z",
+        exclude=[UUID("1946d5f8-44a8-724c-176f-123456aaaa22")],
+        cutoff_date=datetime.fromisoformat("2026-01-01 00:00:00Z"),
     )
 
     # check that function works successfully


### PR DESCRIPTION
The maintenance endpoint has now to extra arguments "exclude" and "cutoff_date" to enhance control of which deprecated transformations should be deleted by this action. In detail:

- include additional arguments + enhance test suit of maintenance function
- re-write code to enhance quality (remove assert statement and unused argument in function)
- enhance run-script description
- enhance typo in autoimport function (automimport -> autoimport)
