### PR TITLE
replace window.location.origin by document.baseURI

### DIFF
--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -83,13 +83,13 @@ const httpLoaderFactory = (configService: ConfigService) => {
     map(config => {
       return {
         authority: config.authConfig?.authority,
-        redirectUrl: `${window.location.origin}/authcallback`,
-        postLogoutRedirectUri: window.location.origin,
+        redirectUrl: `${document.baseURI}authcallback`,
+        postLogoutRedirectUri: document.baseURI,
         clientId: config.authConfig?.clientId,
         responseType: 'code',
         scope: 'openid',
         silentRenew: true,
-        silentRenewUrl: `${window.location.origin}/silent-renew.html`,
+        silentRenewUrl: `${document.baseURI}silent-renew.html`,
         ...config.authConfig
       };
     })
@@ -101,7 +101,7 @@ const httpLoaderFactory = (configService: ConfigService) => {
 const monacoConfig: NgxMonacoEditorConfig = {
   // TODO: Broken default baseUrl seems fixed in "monaco-editor" version "0.54.0".
   // https://github.com/microsoft/monaco-editor/issues/4778
-  baseUrl: `${window.location.origin}/assets/monaco/min/vs`
+  baseUrl: `${document.baseURI}assets/monaco/min/vs`
 };
 
 @NgModule({

--- a/frontend/src/libs/hd-wiring/lib/json-editor/json-editor.component.ts
+++ b/frontend/src/libs/hd-wiring/lib/json-editor/json-editor.component.ts
@@ -117,7 +117,7 @@ export class JsonEditorComponent implements OnInit, AfterViewInit {
                   useValue: {
                     // TODO: Broken default baseUrl seems fixed in "monaco-editor" version "0.54.0".
                     // https://github.com/microsoft/monaco-editor/issues/4778
-                    baseUrl: `${window.location.origin}/assets/monaco/min/vs`
+                    baseUrl: `${document.baseURI}assets/monaco/min/vs`
                   }
                 }
               ],


### PR DESCRIPTION
`window.location.origin` does not work behind a reverse proxy, it has to be overwritten; 
this is possible for authConfig, but not for monacoConfig, so one needs to patch in such setups.

`document.baseURI` seems to be the correct replacement, it includes a trailing slash, and it works both in the local docker-compose setup and the setup with a reverse proxy adding a path "/designer". (Maybe one has more setups that need to be tested?)

In typical cases, this will mean with the fix the container works in all the setups without patching, and one does not need to overwrite `redirectUrl` and `silentRenewUrl` any more.